### PR TITLE
Add support for infectious asymptomatic window

### DIFF
--- a/docs/source/usage/how_to_run.rst
+++ b/docs/source/usage/how_to_run.rst
@@ -85,12 +85,18 @@ In addition to the ExaEpi inputs, there are also a number of runtime options tha
     one entry for each disease strain.
 * ``disease.vac_eff`` (`float`, example: ``0.4``)
     The vaccine efficacy - the probability of transmission will be multiplied by this factor
-* ``disease.incubation_length`` (`int`, default: ``3``)
-    Length of the incubation period in days. Before this, agents have no symptoms and are not infectious.
-* ``disease.infectious_length`` (`int`, default: ``6``)
-    Length of the infectious period in days. This counter starts once the incubation phase is over. Before tihs, agents are symptomatic and can spread the disease.
-* ``disease.symptomatic_length`` (`int`, default: ``5``)
-    Length of the symptomatic-but-not-infectious stage in days. This counter starts once the infectious phase is complete. During this time agents are symptomatic and may self-withdraw, but they cannot spread the illness.
+* ``disease.incubation_length_mean`` (`float`, default: ``3.0``)
+    Mean length of the incubation period in days. Before this, agents have no symptoms and are not infectious.
+* ``disease.infectious_length_mean`` (`float`, default: ``6.0``)
+    Mean length of the infectious period in days. This counter starts once the incubation phase is over. Before tihs, agents are symptomatic and can spread the disease.
+* ``disease.symptomdev_length_mean`` (`float`, default: ``5.0``)
+    Mean length of the time from exposure until symptoms develop in days. During the symptomatic-but-not-infectious stage agents  may self-withdraw, but they cannot spread the illness.
+* ``disease.incubation_length_std`` (`float`, default: ``1.0``)
+    Standard deviation of the incubation period in days.
+* ``disease.infectious_length_std`` (`float`, default: ``1.0``)
+    Standard deviation of the infectious period in days.
+* ``disease.symptomdev_length_std`` (`float`, default: ``1.0``)
+    Standard deviation of the time until symptom development in days.
 * ``agents.size`` (`tuple of 2 integers`: e.g. ``(1, 1)``, default: ``(1, 1)``)
     This option is deprecated and will removed in a future version of ExaEpi. It controls
     the number of cells in the domain when running in `demo` mode. During actual usage,

--- a/src/AgentContainer.H
+++ b/src/AgentContainer.H
@@ -337,6 +337,14 @@ public:
 
     std::array<amrex::Long, 5> printTotals ();
 
+    const DiseaseParm * getDiseaseParameters_h () const {
+        return h_parm;
+    }
+
+    const DiseaseParm * getDiseaseParameters_d () const {
+        return d_parm;
+    }
+
 protected:
 
     DiseaseParm* h_parm;    /*!< Disease parameters */

--- a/src/AgentContainer.H
+++ b/src/AgentContainer.H
@@ -173,6 +173,9 @@ struct RealIdx
         disease_counter = 0,    /*!< Counter since start of infection */
         treatment_timer,        /*!< Timer since hospital admission */
         prob,                   /*!< Probability of infection */
+        incubation_period,      /*!< Time until infectious */
+        infectious_period,       /*!< Length of time infectious */
+        symptomdev_period,       /*!< Time until symptoms would develop */
         nattribs                /*!< number of real-type attribute*/
     };
 };
@@ -205,7 +208,8 @@ struct IntIdx
         school,         /*!< school type (elementary, middle, high, none) */
         workgroup,      /*!< workgroup ID */
         work_nborhood,  /*!< work neighborhood ID */
-        withdrawn,      /*!< quarrantine status */
+        withdrawn,      /*!< quarantine status */
+        symptomatic,    /*!< currently symptomatic? */
         nattribs        /*!< number of integer-type attribute */
     };
 };
@@ -284,9 +288,13 @@ public:
                 h_parm->reduced_inf[i] = reduced_inf[i];
             }
 
-            pp.query("incubation_length", h_parm->incubation_length);
-            pp.query("infectious_length", h_parm->infectious_length);
-            pp.query("symptomatic_length", h_parm->symptomatic_length);
+            pp.query("incubation_length_mean", h_parm->incubation_length_mean);
+            pp.query("infectious_length_mean", h_parm->infectious_length_mean);
+            pp.query("symptomdev_length_mean", h_parm->symptomdev_length_mean);
+
+            pp.query("incubation_length_std", h_parm->incubation_length_std);
+            pp.query("infectious_length_std", h_parm->infectious_length_std);
+            pp.query("symptomdev_length_std", h_parm->symptomdev_length_std);
         }
 
         h_parm->Initialize();

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -819,8 +819,6 @@ void AgentContainer::updateStatus (MultiFab& disease_stats /*!< Community-wise d
                 };
             };
 
-            auto* lparm = d_parm;
-
             // Track hospitalization, ICU, ventilator, and fatalities
             Real CHR[] = {.0104, .0104, .070, .28, 1.0};  // sick -> hospital probabilities
             Real CIC[] = {.24, .24, .24, .36, .35};      // hospital -> ICU probabilities

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -838,7 +838,7 @@ void AgentContainer::updateStatus (MultiFab& disease_stats /*!< Community-wise d
                         // incubation phase
                         return;
                     }
-                    if (counter_ptr[i] == incubation_period_ptr[i]) {
+                    if (counter_ptr[i] == amrex::Math::ceil(incubation_period_ptr[i])) {
                         // decide if hospitalized
                         Real p_hosp = CHR[age_group_ptr[i]];
                         if (amrex::Random(engine) < p_hosp) {
@@ -928,7 +928,7 @@ void AgentContainer::updateStatus (MultiFab& disease_stats /*!< Community-wise d
                             }
                         }
                         else { // not hospitalized, recover once not infectious
-                            if (counter_ptr[i] == incubation_period_ptr[i] + infectious_period_ptr[i]) {
+                            if (counter_ptr[i] >= (incubation_period_ptr[i] + infectious_period_ptr[i])) {
                                 status_ptr[i] = Status::immune;
                             }
                         }

--- a/src/DiseaseParm.H
+++ b/src/DiseaseParm.H
@@ -71,9 +71,13 @@ struct DiseaseParm
     amrex::Real Child_compliance, /*!< Child compliance with masking ?? */
                 Child_HH_closure; /*!< Multiplier for household contacts during school closure */
 
-    int incubation_length  = 3;   /*!< Incubation period of disease (in days) */
-    int infectious_length  = 6;   /*!< Number of days person is infectious */
-    int symptomatic_length = 5;   /*!< Number of days person is symptomatic */ //note, this does not affect the model yet
+    amrex::Real incubation_length_mean = 3.0;   /*!< mean time (in days) until infectious*/
+    amrex::Real infectious_length_mean = 6.0;   /*!< mean time (in days) agents are infectious */
+    amrex::Real symptomdev_length_mean = 5.0;   /*!< mean time (in days) until symptoms show */
+
+    amrex::Real incubation_length_std = 1.0;   /*!< std dev (in days) for the above*/
+    amrex::Real infectious_length_std = 1.0;   /*!< std dev (in days) for the above */
+    amrex::Real symptomdev_length_std = 1.0;   /*!< std dev (in days) for the above */
 
     void Initialize ();
 

--- a/src/Initialization.cpp
+++ b/src/Initialization.cpp
@@ -273,9 +273,15 @@ namespace Initialization
 
             auto status_ptr = soa.GetIntData(IntIdx::status).data();
             auto counter_ptr = soa.GetRealData(RealIdx::disease_counter).data();
+            auto incubation_period_ptr = soa.GetRealData(RealIdx::incubation_period).data();
+            auto infectious_period_ptr = soa.GetRealData(RealIdx::infectious_period).data();
+            auto symptomdev_period_ptr = soa.GetRealData(RealIdx::symptomdev_period).data();
+
             //auto unit_arr = unit_mf[mfi].array();
             auto comm_arr = comm_mf[mfi].array();
             auto bx = mfi.tilebox();
+
+            const auto* lparm = pc.getDiseaseParameters_d();
 
             Gpu::DeviceScalar<int> num_infected_d(num_infected);
             int* num_infected_p = num_infected_d.dataPtr();
@@ -310,6 +316,9 @@ namespace Initialization
                     } else {
                         status_ptr[pindex] = Status::infected;
                         counter_ptr[pindex] = 0;
+                        incubation_period_ptr[pindex] = amrex::RandomNormal(lparm->incubation_length_mean, lparm->incubation_length_std, engine);
+                        infectious_period_ptr[pindex] = amrex::RandomNormal(lparm->infectious_length_mean, lparm->infectious_length_std, engine);
+                        symptomdev_period_ptr[pindex] = amrex::RandomNormal(lparm->symptomdev_length_mean, lparm->symptomdev_length_std, engine);
                         ++ni;
                     }
                 }


### PR DESCRIPTION
This makes the time-to-symptom, time-to-infectiousness, and length-of-infectiousness parameters exposed as runtime parameters and drawn from random distributions for each agent, allowing the possibility of an infectious-but-not-symptomatic window.