### PR TITLE
Fix cpu reduction of mesh variables

### DIFF
--- a/src/Initialization.cpp
+++ b/src/Initialization.cpp
@@ -375,7 +375,7 @@ namespace Initialization
                 for (int i = 0; i < demo.Nunit; ++i) if(demo.FIPS[i]==FIPS)units.push_back(i);
                 //int unit = FIPS_code_to_i[FIPS];
                 if (units.size() > 0) {
-                    printf("Infecting %d people in FIPS %d\n", cases.Size_hubs[ihub], FIPS);
+                    amrex::Print() << "Attempting to infect: " << cases.Size_hubs[ihub] << " people in FIPS " << FIPS << "... ";
                     int u=0;
                     int i=0;
                     while (i < cases.Size_hubs[ihub]) {
@@ -384,7 +384,7 @@ namespace Initialization
                         i+= nSuccesses;
                         u=(u+1)%units.size(); //sometimes we infect fewer than ntry, but switch to next unit anyway
                     }
-                    amrex::Print() << "Infected " << i<< " total " << ninf << " after processing FIPS " << FIPS << " \n";
+                    amrex::Print() << "infected " << i<< " (total " << ninf << ") after processing. \n";
                 }
             }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,7 +201,7 @@ void runAgent ()
             }
             cumulative_deaths = counts[4];
 
-            std::array<Real, 4> mmc = {0, 0, 0, 0};
+            Real mmc[4] = {0, 0, 0, 0};
 #ifdef AMREX_USE_GPU
             if (Gpu::inLaunchRegion()) {
                 auto const& ma = disease_stats.const_arrays();
@@ -217,23 +217,26 @@ void runAgent ()
                                       ma[box_no](ii,jj,kk,2),
                                       ma[box_no](ii,jj,kk,3) };
                          });
-                mmc = {amrex::get<0>(mm), amrex::get<1>(mm), amrex::get<2>(mm), amrex::get<3>(mm)};
+                mmc[0] = amrex::get<0>(mm);
+                mmc[1] = amrex::get<1>(mm);
+                mmc[2] = amrex::get<2>(mm);
+                mmc[3] = amrex::get<3>(mm);
             } else
 #endif
                 {
 #ifdef AMREX_USE_OMP
-#pragma omp parallel if (!system::regtest_reduction) reduction(+:mmc)
+#pragma omp parallel if (!system::regtest_reduction) reduction(+:mmc[:4])
 #endif
                     for (MFIter mfi(disease_stats,true); mfi.isValid(); ++mfi)
                     {
                         Box const& bx = mfi.tilebox();
                         auto const& dfab = disease_stats.const_array(mfi);
-                        AMREX_LOOP_3D(bx, i, j, k,
+                        AMREX_LOOP_3D(bx, ii, jj, kk,
                         {
-                            mmc[0] += dfab(i,j,k,0);
-                            mmc[1] += dfab(i,j,k,1);
-                            mmc[2] += dfab(i,j,k,2);
-                            mmc[3] += dfab(i,j,k,3);
+                            mmc[0] += dfab(ii,jj,kk,0);
+                            mmc[1] += dfab(ii,jj,kk,1);
+                            mmc[2] += dfab(ii,jj,kk,2);
+                            mmc[3] += dfab(ii,jj,kk,3);
                         });
                     }
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -142,6 +142,7 @@ void runAgent ()
     iMultiFab comm_mf(ba, dm, 1, 0);
 
     MultiFab disease_stats(ba, dm, 4, 0);
+    disease_stats.setVal(0);
     MultiFab mask_behavior(ba, dm, 1, 0);
     mask_behavior.setVal(1);
 
@@ -200,8 +201,11 @@ void runAgent ()
             }
             cumulative_deaths = counts[4];
 
-            auto const& ma = disease_stats.const_arrays();
-            GpuTuple<Real,Real,Real,Real> mm = ParReduce(
+            std::array<Real, 4> mmc = {0, 0, 0, 0};
+#ifdef AMREX_USE_GPU
+            if (Gpu::inLaunchRegion()) {
+                auto const& ma = disease_stats.const_arrays();
+                GpuTuple<Real,Real,Real,Real> mm = ParReduce(
                          TypeList<ReduceOpSum,ReduceOpSum,ReduceOpSum,ReduceOpSum>{},
                          TypeList<Real,Real,Real,Real>{},
                          disease_stats, IntVect(0, 0),
@@ -213,13 +217,35 @@ void runAgent ()
                                       ma[box_no](ii,jj,kk,2),
                                       ma[box_no](ii,jj,kk,3) };
                          });
-            std::array<Real, 4> mmc = {amrex::get<0>(mm), amrex::get<1>(mm), amrex::get<2>(mm), amrex::get<3>(mm)};
+                mmc = {amrex::get<0>(mm), amrex::get<1>(mm), amrex::get<2>(mm), amrex::get<3>(mm)};
+            } else
+#endif
+                {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (!system::regtest_reduction) reduction(+:mmc)
+#endif
+                    for (MFIter mfi(disease_stats,true); mfi.isValid(); ++mfi)
+                    {
+                        Box const& bx = mfi.tilebox();
+                        auto const& dfab = disease_stats.const_array(mfi);
+                        AMREX_LOOP_3D(bx, i, j, k,
+                        {
+                            mmc[0] += dfab(i,j,k,0);
+                            mmc[1] += dfab(i,j,k,1);
+                            mmc[2] += dfab(i,j,k,2);
+                            mmc[3] += dfab(i,j,k,3);
+                        });
+                    }
+                }
 
             ParallelDescriptor::ReduceRealSum(&mmc[0], 4, ParallelDescriptor::IOProcessorNumber());
 
             if (ParallelDescriptor::IOProcessor())
             {
                 // total number of deaths computed on agents and on mesh should be the same...
+                if (mmc[3] != counts[4]) {
+                    amrex::Print() << mmc[3] << " " << counts[4] << "\n";
+                }
                 AMREX_ALWAYS_ASSERT(mmc[3] == counts[4]);
 
                 // the total number of infected should equal the sum of


### PR DESCRIPTION
I've also prettied-up the printing for initialization when running on multiple mpi ranks.