### PR TITLE
Read output_filename

### DIFF
--- a/docs/source/usage/how_to_run.rst
+++ b/docs/source/usage/how_to_run.rst
@@ -118,6 +118,8 @@ In addition to the ExaEpi inputs, there are also a number of runtime options tha
     This option sets the maximum grid size used for MPI domain decomposition. If set to
     ``16``, for example, the domain will be broken up into grids of `16^2` communities, and
     these grids will be assigned to different MPI ranks / GPUs.
+* ``diag.output_filename`` (`string`, default: ``output.dat``)
+    Filename for the output data.
 
 
 In addition to the ExaEpi inputs, there are also a number of runtime options that can be configured for AMReX itself. Please see <https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters>`__ for more information on these options.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,7 +115,10 @@ void runAgent ()
     amrex::Print() << "Max grid size is: " << params.max_grid_size << "\n";
     amrex::Print() << "Number of boxes is: " << ba.size() << " over " << ParallelDescriptor::NProcs() << " ranks. \n";
 
+    // The default output filename is output.dat
     std::string output_filename = "output.dat";
+    ParmParse pp("diag");
+    pp.query("output_filename",output_filename);
     if (ParallelDescriptor::IOProcessor())
     {
         std::ofstream File;


### PR DESCRIPTION
This PR allows users to specify a filename for the output
The default filename is output.dat and can be specified through the user-interface "diag.output_filename"
