### PR TITLE
Compliance rate for symptomatic withdrawal

### DIFF
--- a/docs/source/usage/how_to_run.rst
+++ b/docs/source/usage/how_to_run.rst
@@ -69,8 +69,10 @@ In addition to the ExaEpi inputs, there are also a number of runtime options tha
     Number of days shelter in-place-is in effect.
 * ``agent.shelter_compliance`` (`float`)
     Fraction of agents that comply with shelter-in-place order.
-* ``agent.symptomatic_withdraw`` (`integer`)
+* ``agent.symptomatic_withdraw`` (`integer`, default: 1)
     Whether or not to have symptomatic agents withdraw.
+* ``agent.symptomatic_withdraw_compliance`` (`float`, default: 0.95)
+    Compliance rate for agents withdrawing when they have symptoms. Should be 0.0 to 1.0.
 * ``contact.pSC`` (`float`, default: 0.2)
     This is contact matrix scaling factor for schools.
 * ``contact.pCO`` (`float`, default: 1.45)

--- a/src/AgentContainer.H
+++ b/src/AgentContainer.H
@@ -75,6 +75,7 @@ public:
             amrex::ParmParse pp("agent");
             pp.query("symptomatic_withdraw", m_symptomatic_withdraw);
             pp.query("shelter_compliance", m_shelter_compliance);
+            pp.query("symptomatic_withdraw_compliance", m_symptomatic_withdraw_compliance);
         }
 
         {
@@ -210,9 +211,10 @@ public:
 
 protected:
 
-    int m_symptomatic_withdraw = 0;
+    int m_symptomatic_withdraw = 1;
 
     amrex::Real m_shelter_compliance = 0.95_rt;
+    amrex::Real m_symptomatic_withdraw_compliance = 0.95_rt;
 
     DiseaseParm* h_parm;    /*!< Disease parameters */
     DiseaseParm* d_parm;    /*!< Disease parameters (GPU device) */

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -827,6 +827,7 @@ void AgentContainer::updateStatus (MultiFab& disease_stats /*!< Community-wise d
             };
 
             auto symptomatic_withdraw = m_symptomatic_withdraw;
+            auto symptomatic_withdraw_compliance = m_symptomatic_withdraw_compliance;
 
             // Track hospitalization, ICU, ventilator, and fatalities
             Real CHR[] = {.0104_rt, .0104_rt, .070_rt, .28_rt, 1.0_rt};  // sick -> hospital probabilities
@@ -855,7 +856,8 @@ void AgentContainer::updateStatus (MultiFab& disease_stats /*!< Community-wise d
                             symptomatic_ptr[i] = SymptomStatus::symptomatic;
                         }
                         if (    (symptomatic_ptr[i] == SymptomStatus::symptomatic)
-                            &&  symptomatic_withdraw ) {
+                            &&  (symptomatic_withdraw)
+                            &&  (amrex::Random(engine) < symptomatic_withdraw_compliance)) {
                             withdrawn_ptr[i] = 1;
                         }
                     }


### PR DESCRIPTION
This makes two changes. First, voluntary withdrawal for agents with symptoms is turned *on* by default. Second, this now has a compliance rate that by default is 0.95. 