### PR TITLE
Add immunity waning from user-adjustable distribution.

### DIFF
--- a/docs/source/usage/how_to_run.rst
+++ b/docs/source/usage/how_to_run.rst
@@ -73,6 +73,12 @@ In addition to the ExaEpi inputs, there are also a number of runtime options tha
     Whether or not to have symptomatic agents withdraw.
 * ``agent.symptomatic_withdraw_compliance`` (`float`, default: 0.95)
     Compliance rate for agents withdrawing when they have symptoms. Should be 0.0 to 1.0.
+* ``agent.mean_immune_time`` (`float`, default: 180)
+    The mean amount of time *in days* agents are immune post-infection
+* ``agent.immune_time_spread`` (`float`, default: 60)
+    The spread associated with the above mean, each agent will draw uniformly from mean +/- spread
+* ``agent.shelter_compliance`` (`float`)
+    Fraction of agents that comply with shelter-in-place order.
 * ``contact.pSC`` (`float`, default: 0.2)
     This is contact matrix scaling factor for schools.
 * ``contact.pCO`` (`float`, default: 1.45)

--- a/src/AgentContainer.H
+++ b/src/AgentContainer.H
@@ -76,6 +76,8 @@ public:
             pp.query("symptomatic_withdraw", m_symptomatic_withdraw);
             pp.query("shelter_compliance", m_shelter_compliance);
             pp.query("symptomatic_withdraw_compliance", m_symptomatic_withdraw_compliance);
+            pp.query("mean_immune_time", m_mean_immune_time);
+            pp.query("immune_time_spread", m_immune_time_spread);
         }
 
         {
@@ -215,6 +217,9 @@ protected:
 
     amrex::Real m_shelter_compliance = 0.95_rt;
     amrex::Real m_symptomatic_withdraw_compliance = 0.95_rt;
+
+    amrex::Real m_mean_immune_time = 30*6;  /*! six months in days*/
+    amrex::Real m_immune_time_spread = 30*2;  /*! two months in days*/
 
     DiseaseParm* h_parm;    /*!< Disease parameters */
     DiseaseParm* d_parm;    /*!< Disease parameters (GPU device) */


### PR DESCRIPTION
This adds two new inputs parameters, `agent.mean_immune_time` and `agent.immune_time_spread`. These allow users to set the waning period for immunity. Each agents draws their own value from a uniform distribution from mean +/ spread. 

The below shows a comparison of two runs with 1. no waning versus 2. waning with a period of 90 +/- 30 days.

![wane](https://github.com/AMReX-Codes/ExaEpi/assets/4329158/307b85d7-692c-49f2-b58e-3b2aa50485d5)
