### PR TITLE
Add frame generation script

### DIFF
--- a/utilities/plotMovie/generate_frames.py
+++ b/utilities/plotMovie/generate_frames.py
@@ -13,7 +13,7 @@ or in main function, as necessary.
 
 Since US census tracts include territories around the globe, if
 we use this data, some sort of cropping is necessary (i.e. 48-state mainland)
-The script crudely checks if "us" is in the shape file, but we can easily
+The script crudely checks if "_us_" is in the shape file, but we can easily
 change the crop_usa variable in the main function or adjust the generate_plot
 function as desired.
 """
@@ -142,16 +142,16 @@ def generate_plot(per_df, gdf, vmin = None, vmax = None, crop_usa = False):
 if __name__ == "__main__":
     yt.set_log_level(50)
 
-    # CA: data/CA_2020_Census_Tracts/tl_2020_06_tract
-    # BA: data/San_Francisco_Bay_Region_2020_Census_Tracts/region_2020_censustract
-    # US: data/US_2020_Census_Tracts/tl_2020_us_county
     argc = len(sys.argv)
     data_dir = sys.argv[1] if len(sys.argv()) > 1 else "/global/cfs/projectdirs/m3623/test/output_usa/"
     data_names = sorted([os.path.join(data_dir, f) for f in os.listdir(data_dir) if f.startswith("plt")])
     
+    # BA: data/San_Francisco_Bay_Region_2020_Census_Tracts/region_2020_censustract
+    # CA: data/CA_2020_Census_Tracts/tl_2020_06_tract
+    # US: data/US_2020_Census_Tracts/tl_2020_us_county
     prefix = sys.argv[2] if len(sys.argv()) > 2 else "../../data/tl_2020_us_county"
     gdf = get_gdf(prefix)
-    crop_usa = "us" in prefix
+    crop_usa = "_us_" in prefix
 
     output_dir = sys.argv[3] if len(sys.argv()) > 3 else "./frames_usa/"
     for i in range(len(data_names)):

--- a/utilities/plotMovie/generate_frames.py
+++ b/utilities/plotMovie/generate_frames.py
@@ -10,6 +10,12 @@ python generate_frames.py [sim results dir] [.shp dir] [output dir (optional)]
 
 Endpoints of color range can be set in or passed into generate_plot,
 or in main function, as necessary.
+
+Since US census tracts include territories around the globe, if
+we use this data, some sort of cropping is necessary (i.e. 48-state mainland)
+The script crudely checks if "us" is in the shape file, but we can easily
+change the crop_usa variable in the main function or adjust the generate_plot
+function as desired.
 """
 
 import numpy as np
@@ -145,11 +151,12 @@ if __name__ == "__main__":
     
     prefix = sys.argv[2] if len(sys.argv()) > 2 else "../../data/tl_2020_us_county"
     gdf = get_gdf(prefix)
+    crop_usa = "us" in prefix
 
     output_dir = sys.argv[3] if len(sys.argv()) > 3 else "./frames_usa/"
     for i in range(len(data_names)):
         # vmin and vmax are endpoints for color range; 16 > log(population of LA) is a safe upper bound
         # for per-capita, endpoints should be set to much less
-        fig = generate_plot(get_raw_data(data_names[i]), gdf, vmin=0, vmax=16, crop_usa = True)
+        fig = generate_plot(get_raw_data(data_names[i]), gdf, vmin=0, vmax=16, crop_usa = crop_usa)
         fig.savefig(output_dir + "frame{:05d}".format(i))
         plt.close(fig)

--- a/utilities/plotMovie/generate_frames.py
+++ b/utilities/plotMovie/generate_frames.py
@@ -144,17 +144,17 @@ if __name__ == "__main__":
     yt.set_log_level(50)
 
     argc = len(sys.argv)
-    data_dir = sys.argv[1] if len(sys.argv) > 1 else "/global/cfs/projectdirs/m3623/test/output_usa/"
+    data_dir = sys.argv[1] if argc > 1 else "/global/cfs/projectdirs/m3623/test/output_usa/"
     data_names = sorted([os.path.join(data_dir, f) for f in os.listdir(data_dir) if f.startswith("plt")])
     
     # BA: data/San_Francisco_Bay_Region_2020_Census_Tracts/region_2020_censustract
     # CA: data/CA_2020_Census_Tracts/tl_2020_06_tract
     # US: data/US_2020_Census_Tracts/tl_2020_us_county
-    prefix = sys.argv[2] if len(sys.argv) > 2 else "../../data/tl_2020_us_county"
+    prefix = sys.argv[2] if argc > 2 else "../../data/tl_2020_us_county"
     gdf = get_gdf(prefix)
     crop_usa = "_us_" in prefix
 
-    output_dir = sys.argv[3] if len(sys.argv) > 3 else "./frames_usa/"
+    output_dir = sys.argv[3] if argc > 3 else "./frames_usa/"
     for i in range(len(data_names)):
         # vmin and vmax are endpoints for color range; 16 > log(population of LA) is a safe upper bound
         # for per-capita, endpoints should be set to much less

--- a/utilities/plotMovie/generate_frames.py
+++ b/utilities/plotMovie/generate_frames.py
@@ -21,6 +21,7 @@ function as desired.
 import numpy as np
 
 import yt
+from yt.frontends import boxlib
 from yt.frontends.boxlib.data_structures import AMReXDataset
 
 import matplotlib.pyplot as plt
@@ -143,17 +144,17 @@ if __name__ == "__main__":
     yt.set_log_level(50)
 
     argc = len(sys.argv)
-    data_dir = sys.argv[1] if len(sys.argv()) > 1 else "/global/cfs/projectdirs/m3623/test/output_usa/"
+    data_dir = sys.argv[1] if len(sys.argv) > 1 else "/global/cfs/projectdirs/m3623/test/output_usa/"
     data_names = sorted([os.path.join(data_dir, f) for f in os.listdir(data_dir) if f.startswith("plt")])
     
     # BA: data/San_Francisco_Bay_Region_2020_Census_Tracts/region_2020_censustract
     # CA: data/CA_2020_Census_Tracts/tl_2020_06_tract
     # US: data/US_2020_Census_Tracts/tl_2020_us_county
-    prefix = sys.argv[2] if len(sys.argv()) > 2 else "../../data/tl_2020_us_county"
+    prefix = sys.argv[2] if len(sys.argv) > 2 else "../../data/tl_2020_us_county"
     gdf = get_gdf(prefix)
     crop_usa = "_us_" in prefix
 
-    output_dir = sys.argv[3] if len(sys.argv()) > 3 else "./frames_usa/"
+    output_dir = sys.argv[3] if len(sys.argv) > 3 else "./frames_usa/"
     for i in range(len(data_names)):
         # vmin and vmax are endpoints for color range; 16 > log(population of LA) is a safe upper bound
         # for per-capita, endpoints should be set to much less

--- a/utilities/plotMovie/generate_frames.py
+++ b/utilities/plotMovie/generate_frames.py
@@ -1,0 +1,156 @@
+"""
+Generates movie frames based on given .shp files and 
+plotxxxxx/ data results directly from simulation.
+These frames will generally lie in ./frames/, and can be converted
+to movie using ffmpeg, e.g.
+ffmpeg -framerate 1 -r 30 -i frames/frame%05d.png -pix_fmt yuv420p movie.mp4
+Can adjust inputs directly at bottom of file or as command-line input:
+
+python generate_frames.py [sim results dir] [.shp dir] [output dir (optional)]
+
+Endpoints of color range can be set in or passed into generate_plot,
+or in main function, as necessary.
+"""
+
+import numpy as np
+
+import yt
+from yt.frontends import boxlib
+from yt.frontends.boxlib.data_structures import AMReXDataset
+
+import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation
+
+import pandas as pd
+import geopandas as gpd
+from shapely.geometry import shape
+import shapefile
+# import fiona
+
+import os
+import sys
+
+def get_per_data(name: str):
+    """Generate a dataframe mapping FIPS codes to percent of population infected.
+    (total population as measured by # of agents in simulation, not by census info)
+    Input: directory of yt data (often in form of pltxxxxx)
+    Output: pd.DataFrame with columns "FIPS" and "per"
+    """
+
+    ds = AMReXDataset(name)
+    ad = ds.all_data()
+
+    counties = np.unique(ad["FIPS"])
+
+    def get_per(county):
+        mask = ad["FIPS"] == county
+        total = ad["total"][mask].sum()
+        # log(1 + infected/total), defaulting to 0 if total == 0
+        return np.log(1 + ad["infected"][mask].sum().value / total.value) if total != 0 else 0.0
+
+    per_df = pd.DataFrame()
+    per_df["FIPS"] = counties.d.astype(int)
+    per_df["per"] = per_df.apply(lambda row: get_per(row["FIPS"]), axis=1)
+    ds.close()
+    return per_df
+
+def get_raw_data(name: str):
+    """Generate a dataframe mapping FIPS codes to log of population infected.
+    Input: directory of yt data (often in form of pltxxxxx)
+    Output: pd.DataFrame with columns "FIPS" and "per"
+    """
+
+    ds = AMReXDataset(name)
+    ad = ds.all_data()
+
+    counties = np.unique(ad["FIPS"])
+
+    def get_raw(county):
+        mask = ad["FIPS"] == county
+        return np.log(1 + ad["infected"][mask].sum().value)
+
+    raw_df = pd.DataFrame()
+    raw_df["FIPS"] = counties.d.astype(int)
+    raw_df["per"] = raw_df.apply(lambda row: get_raw(row["FIPS"]), axis=1)
+    ds.close()
+    return raw_df
+
+# example: prefix = "../data/San_Francisco_Bay_Region_2020_Census_Tracts/region_2020_censustract"
+def get_gdf(prefix: str):
+    """Generates a GeoDataFrame from .shp, .dbf, and .prj files.
+    All files must be present and must begin with prefix
+    """
+
+    # with open(prefix + ".shp", "rb") as shp, \
+    # open(prefix + ".dbf", "rb") as dbf, \
+    # open(prefix + ".prj", "rb") as prj:
+    #     r = shapefile.Reader(shp=shp, dbf=dbf, prj=prj)
+    #     attributes, geometry = [], []
+    #     field_names = [field[0] for field in r.fields[1:]]  
+    #     for row in r.shapeRecords():  
+    #         geometry.append(shape(row.shape.__geo_interface__))  
+    #         attributes.append(dict(zip(field_names, row.record)))  
+    #     r.close()
+    # gdf = gpd.GeoDataFrame(data = attributes, geometry = geometry)
+    
+    # Below code requires a .shx file but seems to be much faster than above
+    # building .shx file can easily be done for you by running code inside a
+    # with fiona.Env(SHAPE_RESTORE_SHX = "YES"):
+    # block (remember to import fiona explicitly)
+    gdf = gpd.read_file(prefix + ".shp", driver="esri")
+    
+    cols = list(gdf.columns)
+
+    # Try to find county code columns. CAPS for CA/US state data, lowercase for BA data
+    if "STATEFP" in cols and "COUNTYFP" in cols:
+        gdf["FIPS"] = (gdf["STATEFP"] + gdf["COUNTYFP"]).astype("int")
+    elif "statefp" in cols and "countyfp" in cols: 
+        gdf["FIPS"] = (gdf["statefp"] + gdf["countyfp"]).astype("int")
+    else:
+        print("FIPS columns not recognized!")
+    return gdf
+
+def generate_plot(per_df, gdf, vmin = None, vmax = None, crop_usa = False):
+    """Using a DataFrame mapping FIPS to infected percents
+    and a GeoDataFrame with a FIPS column, generates plot
+    """
+
+    per_gdf = gdf.merge(per_df, left_on = "FIPS", right_on = "FIPS")
+
+    fig, ax = plt.subplots(figsize=(10,10))
+    ax.set(aspect='equal', xticks=[], yticks=[])
+    if vmin == None and vmax == None:
+        per_gdf.plot(column= 'per', ax = ax, cmap = "Purples", legend=True)
+    else:
+        per_gdf.plot(column= 'per', ax = ax, cmap = "Purples", legend=True, vmin=vmin, vmax=vmax)
+    
+    # If using tl_2020_us_county, crop to contiguous US states
+    if crop_usa:
+        # including Alaska + Hawaii:
+        # ax.set_ylim((18, 72))
+        # ax.set_xlim((-170, -66))
+        ax.set_xlim((-125, -66))
+        ax.set_ylim((24, 50))
+
+    return fig
+
+if __name__ == "__main__":
+    yt.set_log_level(50)
+
+    # CA: data/CA_2020_Census_Tracts/tl_2020_06_tract
+    # BA: data/San_Francisco_Bay_Region_2020_Census_Tracts/region_2020_censustract
+    # US: data/US_2020_Census_Tracts/tl_2020_us_county
+    argc = len(sys.argv)
+    data_dir = sys.argv[1] if len(sys.argv()) > 1 else "/global/cfs/projectdirs/m3623/test/output_usa/"
+    data_names = sorted([os.path.join(data_dir, f) for f in os.listdir(data_dir) if f.startswith("plt")])
+    
+    prefix = sys.argv[2] if len(sys.argv()) > 2 else "../../data/tl_2020_us_county"
+    gdf = get_gdf(prefix)
+
+    output_dir = sys.argv[3] if len(sys.argv()) > 3 else "./frames_usa/"
+    for i in range(len(data_names)):
+        # vmin and vmax are endpoints for color range; 16 > log(population of LA) is a safe upper bound
+        # for per-capita, endpoints should be set to much less
+        fig = generate_plot(get_raw_data(data_names[i]), gdf, vmin=0, vmax=16, crop_usa = True)
+        fig.savefig(output_dir + "frame{:05d}".format(i))
+        plt.close(fig)

--- a/utilities/plotMovie/generate_frames.py
+++ b/utilities/plotMovie/generate_frames.py
@@ -15,7 +15,6 @@ or in main function, as necessary.
 import numpy as np
 
 import yt
-from yt.frontends import boxlib
 from yt.frontends.boxlib.data_structures import AMReXDataset
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
Generates .png files that can be used as frames for a movie, especially using ffmpeg.
Using ffmpeg on perlmutter seems finicky (need to find the right encoder–yuv works but has no compression, default does not work), but copying the frames onto a local computer and using ffmpeg there is very quick (few seconds for 180 frames).

The color range currently is set manually in the script (as 0 to 16, intended for log(raw count)), but this needs to be adjusted for other cases.

Generating 180 county-resolution frames for the Bay Area or California takes a few minutes, and for the whole US takes around 8-10 minutes.
If plotting the whole US, some latitude/longitude cropping is likely necessary. The script naively checks if "_us_" is in the shape file prefix, but obviously this should be adjusted as necessary.

https://github.com/AMReX-Codes/ExaEpi/assets/43693924/22dc90f5-8d41-4517-bad1-d4f66c52fa2e