### PR TITLE
Removing hospitalized agents from interactions

### DIFF
--- a/src/AgentDefinitions.H
+++ b/src/AgentDefinitions.H
@@ -165,4 +165,13 @@ bool notSusceptible ( const int      a_idx, /*!< Agent index */
             || (a_ptd.m_runtime_idata[i0(a_d)+IntIdxDisease::status][a_idx] == Status::infected) );
 }
 
+/*! \brief Is an agent hospitalized? */
+template <typename PTDType>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+bool isHospitalized ( const int      a_idx, /*!< Agent index */
+                      const PTDType& a_ptd  /*!< Particle tile data */ )
+{
+    return (a_ptd.m_rdata[RealIdx::treatment_timer][a_idx] > 0.0);
+}
+
 #endif

--- a/src/InteractionModHome.H
+++ b/src/InteractionModHome.H
@@ -180,6 +180,7 @@ void InteractionModHome<AC,ACT,ACTD,A>::interactAgents(AC& a_agents, /*!< Agent 
                     AMREX_ALWAYS_ASSERT( (Long) i < np);
 
                     if ( notSusceptible<ACTD>(i, ptd, d) )  { return; }
+                    if ( isHospitalized(i, ptd) )  { return; }
 
                     //Real i_mask = mask_arr(home_i_ptr[i], home_j_ptr[i], 0);
                     for (unsigned int jj = cell_start; jj < cell_stop; ++jj) {
@@ -189,6 +190,7 @@ void InteractionModHome<AC,ACT,ACTD,A>::interactAgents(AC& a_agents, /*!< Agent 
 
                         //Real j_mask = mask_arr(home_i_ptr[j], home_j_ptr[j], 0);
                         if (i == j) continue;
+                        if ( isHospitalized(j, ptd) )  { continue; }
 
                         if ( isInfectious<ACTD>(j, ptd, d) ) {
                             Real social_scale = 1.0_prt;  // TODO this should vary based on cell

--- a/src/InteractionModNborhood.H
+++ b/src/InteractionModNborhood.H
@@ -157,6 +157,7 @@ void InteractionModNborhood<AC,ACT,ACTD,A>::interactAgents( AC& a_agents, /*!< A
 
                     AMREX_ALWAYS_ASSERT( (Long) i < np);
                     if ( notSusceptible<ACTD>(i, ptd, d) )  { return; }
+                    if ( isHospitalized(i, ptd) )  { return; }
 
                     //Real i_mask = mask_arr(home_i_ptr[i], home_j_ptr[i], 0);
                     for (unsigned int jj = cell_start; jj < cell_stop; ++jj) {
@@ -166,6 +167,7 @@ void InteractionModNborhood<AC,ACT,ACTD,A>::interactAgents( AC& a_agents, /*!< A
 
                         //Real j_mask = mask_arr(home_i_ptr[j], home_j_ptr[j], 0);
                         if (i == j) continue;
+                        if ( isHospitalized(j, ptd) )  { continue; }
 
                         if ( isInfectious<ACTD>(j, ptd, d) ) {
                             Real social_scale = 1.0_prt;  // TODO this should vary based on cell

--- a/src/InteractionModSchool.H
+++ b/src/InteractionModSchool.H
@@ -168,6 +168,7 @@ void InteractionModSchool<AC,ACT,ACTD,A>::interactAgents(AC& a_agents, /*!< Agen
 
                     AMREX_ALWAYS_ASSERT( (Long) i < np);
                     if ( notSusceptible<ACTD>(i, ptd, d) )  { return; }
+                    if ( isHospitalized(i, ptd) )  { return; }
 
                     //Real i_mask = mask_arr(home_i_ptr[i], home_j_ptr[i], 0);
                     for (unsigned int jj = cell_start; jj < cell_stop; ++jj) {
@@ -176,6 +177,7 @@ void InteractionModSchool<AC,ACT,ACTD,A>::interactAgents(AC& a_agents, /*!< Agen
                         AMREX_ALWAYS_ASSERT( (Long) j < np);
                         //Real j_mask = mask_arr(home_i_ptr[j], home_j_ptr[j], 0);
                         if (i == j) continue;
+                        if ( isHospitalized(j, ptd) )  { continue; }
 
                         if ( isInfectious<ACTD>(j, ptd, d) ) {
                             Real social_scale = 1.0_prt;  // TODO this should vary based on cell

--- a/src/InteractionModWork.H
+++ b/src/InteractionModWork.H
@@ -149,6 +149,7 @@ void InteractionModWork<AC,ACT,ACTD,A>::interactAgents(AC& a_agents, /*!< Agent 
                     AMREX_ALWAYS_ASSERT( (Long) i < np);
 
                     if ( notSusceptible<ACTD>(i, ptd, d) )  { return; }
+                    if ( isHospitalized(i, ptd) )  { return; }
 
                     //Real i_mask = mask_arr(home_i_ptr[i], home_j_ptr[i], 0);
                     for (unsigned int jj = cell_start; jj < cell_stop; ++jj) {
@@ -157,6 +158,7 @@ void InteractionModWork<AC,ACT,ACTD,A>::interactAgents(AC& a_agents, /*!< Agent 
                         AMREX_ALWAYS_ASSERT( (Long) j < np);
                         //Real j_mask = mask_arr(home_i_ptr[j], home_j_ptr[j], 0);
                         if (i == j) continue;
+                        if ( isHospitalized(j, ptd) )  { continue; }
 
                         if ( isInfectious<ACTD>(j, ptd, d) ) {
                             Real work_scale = 1.0_prt;  // TODO this should vary based on cell


### PR DESCRIPTION
Right now, hospitalized agents are participating in all the interactions (work/school/neighborhood/home). Whether an agent is hospitalized is indicated by `treatment_timer > 0`; however, agents to undergo interactions are only filtered by their `withdrawn` status. So, filtering out agents whose `treatment_timer > 0` will remove hospitalized agents from interactions.
