### PR TITLE
Fixed an issue with uninitialized member variable

### DIFF
--- a/src/AgentContainer.H
+++ b/src/AgentContainer.H
@@ -78,8 +78,8 @@ public:
           student_counts(a_ba, a_dmap, SchoolType::total_school_type, 0)
     {
         BL_PROFILE("AgentContainer::AgentContainer");
-        AMREX_ASSERT(m_num_diseases < ExaEpi::max_num_diseases);
         m_num_diseases = a_num_diseases;
+        AMREX_ASSERT(m_num_diseases < ExaEpi::max_num_diseases);
         m_disease_names = a_disease_names;
 
         student_counts.setVal(0);  // Initialize the MultiFab to zero


### PR DESCRIPTION
`AMREX_ASSERT` was being called `AgentContainer::m_num_diseases` before it was even set to its correct value in the constructor `AgentContainer()`; consequently causing code to crash when compiler doesn't initialize variables to zero.