### PR TITLE
Removed unnecessary atomic ops

### DIFF
--- a/src/InteractionModHome.H
+++ b/src/InteractionModHome.H
@@ -22,7 +22,8 @@ static void binaryInteractionHome ( const int a_i, /*!< Index of infectious agen
                                     const PTDType& a_ptd, /*!< Particle tile data */
                                     const DiseaseParm* const a_lparm,  /*!< disease paramters */
                                     const Real a_social_scale, /*!< Social scale */
-                                    ParticleReal* const a_prob_ptr /*!< infection probability */)
+                                    ParticleReal* const a_prob_ptr, /*!< infection probability */
+                                    const int a_thread /*!< agent index of this thread */)
 {
     Real infect = a_lparm->infect;
     infect *= a_lparm->vac_eff;
@@ -71,7 +72,8 @@ static void binaryInteractionHome ( const int a_i, /*!< Index of infectious agen
         }
     }
 
-    Gpu::Atomic::Multiply(&a_prob_ptr[a_j], prob);
+    AMREX_ALWAYS_ASSERT(a_j == a_thread);
+    a_prob_ptr[a_j] *= prob;
 }
 
 /*! \brief Class describing agent interactions at home */
@@ -194,7 +196,12 @@ void InteractionModHome<AC,ACT,ACTD,A>::interactAgents(AC& a_agents, /*!< Agent 
 
                         if ( isInfectious<ACTD>(j, ptd, d) ) {
                             Real social_scale = 1.0_prt;  // TODO this should vary based on cell
-                            binaryInteractionHome<ACTD>( j, i, ptd, lparm, social_scale, prob_ptr );
+                            binaryInteractionHome<ACTD>( j, i,
+                                                         ptd,
+                                                         lparm,
+                                                         social_scale,
+                                                         prob_ptr,
+                                                         i );
                         }
                     }
                 });

--- a/src/InteractionModHome.H
+++ b/src/InteractionModHome.H
@@ -72,7 +72,7 @@ static void binaryInteractionHome ( const int a_i, /*!< Index of infectious agen
         }
     }
 
-    AMREX_ALWAYS_ASSERT(a_j == a_thread);
+    AMREX_ASSERT(a_j == a_thread);
     a_prob_ptr[a_j] *= prob;
 }
 

--- a/src/InteractionModNborhood.H
+++ b/src/InteractionModNborhood.H
@@ -55,7 +55,7 @@ static void binaryInteractionNborhood ( const int a_i, /*!< Index of infectious 
         }
     }
 
-    AMREX_ALWAYS_ASSERT(a_j == a_thread);
+    AMREX_ASSERT(a_j == a_thread);
     a_prob_ptr[a_j] *= prob;
 }
 

--- a/src/InteractionModNborhood.H
+++ b/src/InteractionModNborhood.H
@@ -21,7 +21,8 @@ static void binaryInteractionNborhood ( const int a_i, /*!< Index of infectious 
                                         const PTDType& a_ptd, /*!< Particle tile data */
                                         const DiseaseParm* const a_lparm, /*!< disease paramters */
                                         const Real a_social_scale, /*!< Social scale */
-                                        ParticleReal* const a_prob_ptr /*!< infection probability */)
+                                        ParticleReal* const a_prob_ptr, /*!< infection probability */
+                                        const int a_thread /*!< agent index of this thread */)
 {
     Real infect = a_lparm->infect;
     infect *= a_lparm->vac_eff;
@@ -54,7 +55,8 @@ static void binaryInteractionNborhood ( const int a_i, /*!< Index of infectious 
         }
     }
 
-    Gpu::Atomic::Multiply(&a_prob_ptr[a_j], prob);
+    AMREX_ALWAYS_ASSERT(a_j == a_thread);
+    a_prob_ptr[a_j] *= prob;
 }
 
 /*! \brief Class describing agent interactions in the neighborhood/community */
@@ -171,7 +173,12 @@ void InteractionModNborhood<AC,ACT,ACTD,A>::interactAgents( AC& a_agents, /*!< A
 
                         if ( isInfectious<ACTD>(j, ptd, d) ) {
                             Real social_scale = 1.0_prt;  // TODO this should vary based on cell
-                            binaryInteractionNborhood<ACTD>( j, i, ptd, lparm, social_scale, prob_ptr );
+                            binaryInteractionNborhood<ACTD>( j, i,
+                                                             ptd,
+                                                             lparm,
+                                                             social_scale,
+                                                             prob_ptr,
+                                                             i );
                         }
                     }
                 });

--- a/src/InteractionModSchool.H
+++ b/src/InteractionModSchool.H
@@ -21,7 +21,8 @@ static void binaryInteractionSchool ( const int a_i, /*!< Index of infectious ag
                                       const PTDType& a_ptd, /*!< Particle tile data */
                                       const DiseaseParm* const a_lparm, /*!< disease paramters */
                                       const Real a_social_scale,  /*!< Social scale */
-                                      ParticleReal* const a_prob_ptr /*!< infection probability */)
+                                      ParticleReal* const a_prob_ptr, /*!< infection probability */
+                                      const int a_thread /*!< agent index of this thread */)
 {
     Real infect = a_lparm->infect;
     infect *= a_lparm->vac_eff;
@@ -61,7 +62,9 @@ static void binaryInteractionSchool ( const int a_i, /*!< Index of infectious ag
             prob *= 1.0_prt - infect * a_lparm->xmit_sch_a2c[school_ptr[a_i]] * a_social_scale;
         }
     }
-    Gpu::Atomic::Multiply(&a_prob_ptr[a_j], prob);
+
+    AMREX_ALWAYS_ASSERT(a_j == a_thread);
+    a_prob_ptr[a_j] *= prob;
 }
 
 /*! \brief Class describing agent interactions at school */
@@ -181,7 +184,12 @@ void InteractionModSchool<AC,ACT,ACTD,A>::interactAgents(AC& a_agents, /*!< Agen
 
                         if ( isInfectious<ACTD>(j, ptd, d) ) {
                             Real social_scale = 1.0_prt;  // TODO this should vary based on cell
-                            binaryInteractionSchool<ACTD>(  j, i, ptd, lparm, social_scale, prob_ptr );
+                            binaryInteractionSchool<ACTD>(  j, i,
+                                                            ptd,
+                                                            lparm,
+                                                            social_scale,
+                                                            prob_ptr,
+                                                            i );
 
                         }
                     }

--- a/src/InteractionModSchool.H
+++ b/src/InteractionModSchool.H
@@ -63,7 +63,7 @@ static void binaryInteractionSchool ( const int a_i, /*!< Index of infectious ag
         }
     }
 
-    AMREX_ALWAYS_ASSERT(a_j == a_thread);
+    AMREX_ASSERT(a_j == a_thread);
     a_prob_ptr[a_j] *= prob;
 }
 

--- a/src/InteractionModWork.H
+++ b/src/InteractionModWork.H
@@ -44,7 +44,7 @@ static void binaryInteractionWork ( const int a_i, /*!< Index of infectious agen
         }
     }
 
-    AMREX_ALWAYS_ASSERT(a_j == a_thread);
+    AMREX_ASSERT(a_j == a_thread);
     a_prob_ptr[a_j] *= prob;
 }
 

--- a/src/InteractionModWork.H
+++ b/src/InteractionModWork.H
@@ -21,7 +21,8 @@ static void binaryInteractionWork ( const int a_i, /*!< Index of infectious agen
                                     const PTDType& a_ptd, /*!< Particle tile data */
                                     const DiseaseParm* const a_lparm, /*!< disease paramters */
                                     const Real a_work_scale, /*!< Work scale */
-                                    ParticleReal* const a_prob_ptr /*!< infection probability */)
+                                    ParticleReal* const a_prob_ptr, /*!< infection probability */
+                                    const int a_thread /*!< agent index of this thread */)
 {
     Real infect = a_lparm->infect;
     infect *= a_lparm->vac_eff;
@@ -43,7 +44,8 @@ static void binaryInteractionWork ( const int a_i, /*!< Index of infectious agen
         }
     }
 
-    Gpu::Atomic::Multiply(&a_prob_ptr[a_j], prob);
+    AMREX_ALWAYS_ASSERT(a_j == a_thread);
+    a_prob_ptr[a_j] *= prob;
 }
 
 /*! \brief Class describing agent interactions at work */
@@ -162,7 +164,12 @@ void InteractionModWork<AC,ACT,ACTD,A>::interactAgents(AC& a_agents, /*!< Agent 
 
                         if ( isInfectious<ACTD>(j, ptd, d) ) {
                             Real work_scale = 1.0_prt;  // TODO this should vary based on cell
-                            binaryInteractionWork<ACTD>( j, i, ptd, lparm, work_scale, prob_ptr );
+                            binaryInteractionWork<ACTD>( j, i,
+                                                         ptd,
+                                                         lparm,
+                                                         work_scale,
+                                                         prob_ptr,
+                                                         i );
                         }
                     }
                 });


### PR DESCRIPTION
Removed the atomic multiply operations in the interaction models, for example [here](https://github.com/AMReX-Codes/ExaEpi/blob/d67ad053ed34c623dc0213b67398ad7a0ba537d7/src/InteractionModHome.H#L74). But added an [`AMREX_ALWAYS_ASSERT` check ](https://github.com/AMReX-Codes/ExaEpi/blob/5dca0c331d02c0cc7bbb61722fb5c6c4ac43414c/src/InteractionModHome.H#L75) to make sure it is indeed okay to multiply non-atomically.