### PR TITLE
Fix and update random travel

### DIFF
--- a/src/AgentContainer.H
+++ b/src/AgentContainer.H
@@ -78,7 +78,7 @@ public:
           student_counts(a_ba, a_dmap, SchoolType::total_school_type, 0)
     {
         BL_PROFILE("AgentContainer::AgentContainer");
-        AMREX_ASSERT(m_num_diseases < ExaEpi::max_num_diseases);
+        AMREX_ASSERT(a_num_diseases < ExaEpi::max_num_diseases);
         m_num_diseases = a_num_diseases;
         m_disease_names = a_disease_names;
 
@@ -105,6 +105,7 @@ public:
             m_interactions[InteractionNames::work] = new InteractionModWork<PCType,PTileType,PTDType,PType>;
             m_interactions[InteractionNames::school] = new InteractionModSchool<PCType,PTileType,PTDType,PType>;
             m_interactions[InteractionNames::nborhood] = new InteractionModNborhood<PCType,PTileType,PTDType,PType>;
+            m_interactions[InteractionNames::random] = new InteractionModRandom<PCType,PTileType, PTDType, PType>;
         }
 
         h_parm.resize(m_num_diseases);
@@ -244,9 +245,13 @@ public:
 
     void interactNight(amrex::MultiFab&);
 
+    void interactRandomTravel(amrex::MultiFab&, AgentContainer& on_travel_pc);
+
     void moveAgentsRandomWalk ();
 
-    void moveRandomTravel ();
+    void moveRandomTravel (const amrex::iMultiFab& unit_mf);
+
+    void returnRandomTravel ();
 
     void updateStatus (MFPtrVec& ds);
 
@@ -277,6 +282,8 @@ public:
         } else if (a_mod_name == ExaEpi::InteractionNames::nborhood) {
             if (m_at_work) { return &m_bins_work[a_idx]; }
             else           { return &m_bins_home[a_idx]; }
+        } else if (a_mod_name == ExaEpi::InteractionNames::random) {
+            return &m_bins_random[a_idx];
         } else {
             amrex::Abort("Invalid a_mod_name!");
             return nullptr;
@@ -350,6 +357,9 @@ protected:
     /*! Map of work bins (of agents) indexed by MultiFab iterator and tile index;
         see AgentContainer::interactAgentsHomeWork() */
     std::map<std::pair<int, int>, amrex::DenseBins<PType> > m_bins_work;
+    /*! Map of random travel bins (of agents) indexed by MultiFab iterator and tile index;
+        see AgentContainer::interactAgentsRandom() */
+    std::map<std::pair<int, int>, amrex::DenseBins<PType> > m_bins_random;
 
     std::map<std::string,IntModel*> m_interactions;
 

--- a/src/AgentContainer.H
+++ b/src/AgentContainer.H
@@ -251,7 +251,7 @@ public:
 
     void moveRandomTravel (const amrex::iMultiFab& unit_mf);
 
-    void returnRandomTravel ();
+    void returnRandomTravel (const AgentContainer& on_travel_pc);
 
     void updateStatus (MFPtrVec& ds);
 

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -913,7 +913,7 @@ void AgentContainer::returnRandomTravel (const AgentContainer& on_travel_pc)
             const auto& aos_travel   = ptile_travel.GetArrayOfStructs();
             //const ParticleType* pstruct_travel = &(aos_travel[0]);
             const size_t np_travel = aos_travel.numParticles();
-            auto& soa_travel= ptile.GetStructOfArrays();
+            auto& soa_travel= ptile_travel.GetStructOfArrays();
             auto random_travel_ptr_travel = soa_travel.GetIntData(IntIdx::random_travel).data();
 
             int r_RT = RealIdx::nattribs;
@@ -926,7 +926,7 @@ void AgentContainer::returnRandomTravel (const AgentContainer& on_travel_pc)
                     [=] AMREX_GPU_DEVICE (int i) noexcept
                     {
                         int dst_index = random_travel_ptr_travel[i];
-                        prob_ptr[dst_index] = prob_ptr_travel[i];
+                        prob_ptr[dst_index] += prob_ptr_travel[i];
                         AMREX_ALWAYS_ASSERT(random_travel_ptr[dst_index] = dst_index);
                         AMREX_ALWAYS_ASSERT(random_travel_ptr[dst_index] >= 0);
                         random_travel_ptr[dst_index] = -1;

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -872,8 +872,8 @@ void AgentContainer::moveRandomTravel (const iMultiFab& unit_mf)
                     random_travel_ptr[i] = i;
                     int random_unit = -1;
                     while (random_unit == -1) {
-                        int i_random = (int) i_max*amrex::Random(engine);
-                        int j_random = (int) j_max*amrex::Random(engine);
+                        int i_random = int( amrex::Real(i_max)*amrex::Random(engine));
+                        int j_random = int( amrex::Real(j_max)*amrex::Random(engine));
                         p.pos(0) = i_random;
                         p.pos(1) = j_random;
                         random_unit = unit_arr(i_random, j_random, 0);
@@ -903,7 +903,6 @@ void AgentContainer::returnRandomTravel (const AgentContainer& on_travel_pc)
             int gid = mfi.index();
             int tid = mfi.LocalTileIndex();
             auto& ptile = plev[std::make_pair(gid, tid)];
-            auto& aos   = ptile.GetArrayOfStructs();
             auto& soa   = ptile.GetStructOfArrays();
             auto random_travel_ptr = soa.GetIntData(IntIdx::random_travel).data();
 

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -872,8 +872,8 @@ void AgentContainer::moveRandomTravel (const iMultiFab& unit_mf)
                     random_travel_ptr[i] = i;
                     int random_unit = -1;
                     while (random_unit == -1) {
-                        int i_random = i_max*amrex::Random(engine);
-                        int j_random = j_max*amrex::Random(engine);
+                        int i_random = (int) i_max*amrex::Random(engine);
+                        int j_random = (int) j_max*amrex::Random(engine);
                         p.pos(0) = i_random;
                         p.pos(1) = j_random;
                         random_unit = unit_arr(i_random, j_random, 0);
@@ -904,14 +904,11 @@ void AgentContainer::returnRandomTravel (const AgentContainer& on_travel_pc)
             int tid = mfi.LocalTileIndex();
             auto& ptile = plev[std::make_pair(gid, tid)];
             auto& aos   = ptile.GetArrayOfStructs();
-            //ParticleType* pstruct = &(aos[0]);
-            const size_t np = aos.numParticles();
             auto& soa   = ptile.GetStructOfArrays();
             auto random_travel_ptr = soa.GetIntData(IntIdx::random_travel).data();
 
             const auto& ptile_travel = plev_travel.at(std::make_pair(gid, tid));
             const auto& aos_travel   = ptile_travel.GetArrayOfStructs();
-            //const ParticleType* pstruct_travel = &(aos_travel[0]);
             const size_t np_travel = aos_travel.numParticles();
             auto& soa_travel= ptile_travel.GetStructOfArrays();
             auto random_travel_ptr_travel = soa_travel.GetIntData(IntIdx::random_travel).data();

--- a/src/AgentDefinitions.H
+++ b/src/AgentDefinitions.H
@@ -52,6 +52,7 @@ struct IntIdx
         workgroup,      /*!< workgroup ID */
         work_nborhood,  /*!< work neighborhood ID */
         withdrawn,      /*!< quarantine status */
+        random_travel,  /*!< on long distance travel? */
         nattribs        /*!< number of integer-type attribute */
     };
 };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ set(_sources
          InteractionModGeneric.H
          InteractionModHome.H
          InteractionModNborhood.H
+         InteractionModRandom.H
          InteractionModSchool.H
          InteractionModWork.H
          InteractionModelLibrary.H

--- a/src/HospitalModel.H
+++ b/src/HospitalModel.H
@@ -29,6 +29,9 @@ class HospitalModel : public InteractionModel<AC,ACT,ACTD,A>
             // not yet implemented
         }
 
+        /*! \brief Simulate agent interaction in the hospital for agents on travel */
+        virtual void interactAgents( AC&, MultiFab&, AC& ) {}
+
         using MFPtr = std::unique_ptr<MultiFab>;
         using MFPtrVec = std::vector<MFPtr>;
 

--- a/src/HospitalModel.H
+++ b/src/HospitalModel.H
@@ -30,7 +30,7 @@ class HospitalModel : public InteractionModel<AC,ACT,ACTD,A>
         }
 
         /*! \brief Simulate agent interaction in the hospital for agents on travel */
-        virtual void interactAgents( AC&, MultiFab&, AC& ) {}
+        virtual void interactAgents( AC&, MultiFab&, AC& ) override {}
 
         using MFPtr = std::unique_ptr<MultiFab>;
         using MFPtrVec = std::vector<MFPtr>;

--- a/src/IO.cpp
+++ b/src/IO.cpp
@@ -122,6 +122,7 @@ void writePlotFile (const AgentContainer& pc, /*!< Agent (particle) container */
         int_varnames.push_back ("workgroup"); write_int_comp.push_back(static_cast<int>(step==0));
         int_varnames.push_back ("work_nborhood"); write_int_comp.push_back(static_cast<int>(step==0));
         int_varnames.push_back ("withdrawn"); write_int_comp.push_back(1);
+        int_varnames.push_back ("random_travel"); write_int_comp.push_back(1);
         // disease-specific (runtime-added) attributes
         if (num_diseases == 1) {
             real_varnames.push_back("disease_counter"); write_real_comp.push_back(1);

--- a/src/InteractionModGeneric.H
+++ b/src/InteractionModGeneric.H
@@ -26,7 +26,7 @@ class InteractionModGeneric : public InteractionModel<AC,ACT,ACTD,A>
         virtual void interactAgents( AC&, MultiFab& );
 
         /*! \brief Simulate agent interaction with a simple generic model */
-        virtual void interactAgents( AC&, MultiFab&, AC& ) {};
+        virtual void interactAgents( AC&, MultiFab&, AC& ) {}
 
     protected:
 

--- a/src/InteractionModGeneric.H
+++ b/src/InteractionModGeneric.H
@@ -26,7 +26,7 @@ class InteractionModGeneric : public InteractionModel<AC,ACT,ACTD,A>
         virtual void interactAgents( AC&, MultiFab& ) override;
 
         /*! \brief Simulate agent interaction with a simple generic model */
-        virtual void interactAgents( AC&, MultiFab&, AC& ) {}
+        virtual void interactAgents( AC&, MultiFab&, AC& ) override {}
 
     protected:
 

--- a/src/InteractionModGeneric.H
+++ b/src/InteractionModGeneric.H
@@ -25,6 +25,9 @@ class InteractionModGeneric : public InteractionModel<AC,ACT,ACTD,A>
         /*! \brief Simulate agent interaction with a simple generic model */
         virtual void interactAgents( AC&, MultiFab& );
 
+        /*! \brief Simulate agent interaction with a simple generic model */
+        virtual void interactAgents( AC&, MultiFab&, AC& ) {};
+
     protected:
 
     private:

--- a/src/InteractionModGeneric.H
+++ b/src/InteractionModGeneric.H
@@ -26,7 +26,9 @@ class InteractionModGeneric : public InteractionModel<AC,ACT,ACTD,A>
         virtual void interactAgents( AC&, MultiFab& ) override;
 
         /*! \brief Simulate agent interaction with a simple generic model */
-        virtual void interactAgents( AC&, MultiFab&, AC& ) override {}
+        virtual void interactAgents( AC&, MultiFab&, AC& ) override {
+            amrex::Abort("Do not use this interface for this interaction model");
+        }
 
     protected:
 

--- a/src/InteractionModHome.H
+++ b/src/InteractionModHome.H
@@ -94,7 +94,7 @@ class InteractionModHome : public InteractionModel<AC,ACT,ACTD,A>
         virtual void interactAgents( AC&, MultiFab& ) override;
 
         /*! \brief Simulate agent interaction at home */
-        virtual void interactAgents( AC&, MultiFab&, AC& ) {}
+        virtual void interactAgents( AC&, MultiFab&, AC& ) override {}
 
     protected:
 

--- a/src/InteractionModHome.H
+++ b/src/InteractionModHome.H
@@ -94,7 +94,7 @@ class InteractionModHome : public InteractionModel<AC,ACT,ACTD,A>
         virtual void interactAgents( AC&, MultiFab& );
 
         /*! \brief Simulate agent interaction at home */
-        virtual void interactAgents( AC&, MultiFab&, AC& ) {};
+        virtual void interactAgents( AC&, MultiFab&, AC& ) {}
 
     protected:
 

--- a/src/InteractionModHome.H
+++ b/src/InteractionModHome.H
@@ -94,7 +94,9 @@ class InteractionModHome : public InteractionModel<AC,ACT,ACTD,A>
         virtual void interactAgents( AC&, MultiFab& ) override;
 
         /*! \brief Simulate agent interaction at home */
-        virtual void interactAgents( AC&, MultiFab&, AC& ) override {}
+        virtual void interactAgents( AC&, MultiFab&, AC& ) override {
+            amrex::Abort("Do not use this interface for this interaction model");
+        }
 
     protected:
 

--- a/src/InteractionModHome.H
+++ b/src/InteractionModHome.H
@@ -33,7 +33,7 @@ static void binaryInteractionHome ( const int a_i, /*!< Index of infectious agen
     auto school_ptr = a_ptd.m_idata[IntIdx::school];
     auto withdrawn_ptr = a_ptd.m_idata[IntIdx::withdrawn];
     auto random_travel_ptr = a_ptd.m_idata[IntIdx::random_travel];
-    if (random_travel_ptr[a_i] || random_travel_ptr[a_j]) {return;}
+    if ((random_travel_ptr[a_i] >= 0) || (random_travel_ptr[a_j] >= 0)) {return;}
 
     //infect *= i_mask;
     //infect *= j_mask;

--- a/src/InteractionModHome.H
+++ b/src/InteractionModHome.H
@@ -32,6 +32,8 @@ static void binaryInteractionHome ( const int a_i, /*!< Index of infectious agen
     auto nborhood_ptr = a_ptd.m_idata[IntIdx::nborhood];
     auto school_ptr = a_ptd.m_idata[IntIdx::school];
     auto withdrawn_ptr = a_ptd.m_idata[IntIdx::withdrawn];
+    auto random_travel_ptr = a_ptd.m_idata[IntIdx::random_travel];
+    if (random_travel_ptr[a_i] || random_travel_ptr[a_j]) {return;}
 
     //infect *= i_mask;
     //infect *= j_mask;
@@ -88,6 +90,9 @@ class InteractionModHome : public InteractionModel<AC,ACT,ACTD,A>
 
         /*! \brief Simulate agent interaction at home */
         virtual void interactAgents( AC&, MultiFab& );
+
+        /*! \brief Simulate agent interaction at home */
+        virtual void interactAgents( AC&, MultiFab&, AC& ) {};
 
     protected:
 

--- a/src/InteractionModNborhood.H
+++ b/src/InteractionModNborhood.H
@@ -87,7 +87,7 @@ class InteractionModNborhood : public InteractionModel<AC,ACT,ACTD,A>
         virtual void interactAgents( AC&, MultiFab& ) override;
 
         /*! \brief Simulate agent interaction in the neighborhood/community */
-        virtual void interactAgents( AC&, MultiFab&, AC& ) {}
+        virtual void interactAgents( AC&, MultiFab&, AC& ) override {}
 
     protected:
 

--- a/src/InteractionModNborhood.H
+++ b/src/InteractionModNborhood.H
@@ -32,7 +32,7 @@ static void binaryInteractionNborhood ( const int a_i, /*!< Index of infectious 
     auto withdrawn_ptr = a_ptd.m_idata[IntIdx::withdrawn];
     if (withdrawn_ptr[a_i] || withdrawn_ptr[a_j]) { return; }
     auto random_travel_ptr = a_ptd.m_idata[IntIdx::random_travel];
-    if (random_travel_ptr[a_i] || random_travel_ptr[a_j]) {return;}
+    if ((random_travel_ptr[a_i] >= 0) || (random_travel_ptr[a_j] >= 0)) {return;}
 
     //infect *= i_mask;
     //infect *= j_mask;

--- a/src/InteractionModNborhood.H
+++ b/src/InteractionModNborhood.H
@@ -30,8 +30,9 @@ static void binaryInteractionNborhood ( const int a_i, /*!< Index of infectious 
     auto nborhood_ptr = a_ptd.m_idata[IntIdx::nborhood];
     auto school_ptr = a_ptd.m_idata[IntIdx::school];
     auto withdrawn_ptr = a_ptd.m_idata[IntIdx::withdrawn];
-
     if (withdrawn_ptr[a_i] || withdrawn_ptr[a_j]) { return; }
+    auto random_travel_ptr = a_ptd.m_idata[IntIdx::random_travel];
+    if (random_travel_ptr[a_i] || random_travel_ptr[a_j]) {return;}
 
     //infect *= i_mask;
     //infect *= j_mask;
@@ -71,6 +72,9 @@ class InteractionModNborhood : public InteractionModel<AC,ACT,ACTD,A>
 
         /*! \brief Simulate agent interaction in the neighborhood/community */
         virtual void interactAgents( AC&, MultiFab& );
+
+        /*! \brief Simulate agent interaction in the neighborhood/community */
+        virtual void interactAgents( AC&, MultiFab&, AC& ) {};
 
     protected:
 

--- a/src/InteractionModNborhood.H
+++ b/src/InteractionModNborhood.H
@@ -87,7 +87,9 @@ class InteractionModNborhood : public InteractionModel<AC,ACT,ACTD,A>
         virtual void interactAgents( AC&, MultiFab& ) override;
 
         /*! \brief Simulate agent interaction in the neighborhood/community */
-        virtual void interactAgents( AC&, MultiFab&, AC& ) override {}
+        virtual void interactAgents( AC&, MultiFab&, AC& ) override {
+            amrex::Abort("Do not use this interface for this interaction model");
+        }
 
     protected:
 

--- a/src/InteractionModNborhood.H
+++ b/src/InteractionModNborhood.H
@@ -76,7 +76,7 @@ class InteractionModNborhood : public InteractionModel<AC,ACT,ACTD,A>
         virtual void interactAgents( AC&, MultiFab& );
 
         /*! \brief Simulate agent interaction in the neighborhood/community */
-        virtual void interactAgents( AC&, MultiFab&, AC& ) {};
+        virtual void interactAgents( AC&, MultiFab&, AC& ) {}
 
     protected:
 

--- a/src/InteractionModRandom.H
+++ b/src/InteractionModRandom.H
@@ -76,7 +76,7 @@ class InteractionModRandom : public InteractionModel<AC,ACT,ACTD,A>
         virtual ~InteractionModRandom() = default;
 
         /*! \brief Simulate agent interaction for random travel */
-        void interactAgents( AC&, MultiFab&) {};
+        void interactAgents( AC&, MultiFab&) {}
 
         /*! \brief Simulate agent interaction for random travel */
         void interactAgents( AC&, MultiFab&, AC&);

--- a/src/InteractionModRandom.H
+++ b/src/InteractionModRandom.H
@@ -88,37 +88,7 @@ class InteractionModRandom : public InteractionModel<AC,ACT,ACTD,A>
     private:
 };
 
-/*! Simulate the interactions between agents at home and compute
-    the infection probability for each agent:
-
-    + Create bins of agents if not already created (see
-      #amrex::GetParticleBin, #amrex::DenseBins):
-      + The bin size is 1 cell
-      + #amrex::GetParticleBin maps a particle to its bin index
-      + amrex::DenseBins::build() creates the bin-sorted array of particle indices and
-        the offset array for each bin (where the offset of a bin is its starting location
-        in the bin-sorted array of particle indices).
-
-    + For each agent *i* in the bin-sorted array of agents:
-      + Find its bin and the range of indices in the bin-sorted array for agents in its bin
-      + If the agent is #Status::immune, do nothing.
-      + If the agent is #Status::infected with the number of days infected (RealIdxDisease::disease_counter)
-        less than the incubation length, do nothing.
-      + Else, for each agent *j* in the same bin:
-        + If the agent is #Status::immune, do nothing.
-        + If the agent is #Status::infected with the number of days infected (RealIdxDisease::disease_counter)
-          less than the incubation length, do nothing.
-        + Else if *i* is not infected and *j* is infected, compute probability of *i* getting infected
-          from *j* (see below).
-
-    Summary of how the probability of agent A getting infected from agent B is computed:
-    + Compute infection probability reduction factor from vaccine efficacy (#DiseaseParm::vac_eff)
-    + Within family - if their IntIdx::nborhood and IntIdx::family indices are same,
-      and the agents are at home:
-      + If B is a child, use the appropriate transmission probability (#DiseaseParm::xmit_child_SC or
-        #DiseaseParm::xmit_child) depending on whether B goes to school or not (#IntIdx::school)
-      + If B is an adult, use the appropriate transmission probability (#DiseaseParm::xmit_adult_SC or
-        #DiseaseParm::xmit_adult) depending on whether B works at a school or not (#IntIdx::school)
+/*! Simulate the interactions for agents on random travel
 */
 template <typename AC, typename ACT, typename ACTD, typename A>
 void InteractionModRandom<AC,ACT,ACTD,A>::interactAgents(AC& a_agents, /*!< Agent container */

--- a/src/InteractionModRandom.H
+++ b/src/InteractionModRandom.H
@@ -76,7 +76,9 @@ class InteractionModRandom : public InteractionModel<AC,ACT,ACTD,A>
         virtual ~InteractionModRandom() = default;
 
         /*! \brief Simulate agent interaction for random travel */
-        void interactAgents( AC&, MultiFab&) override {}
+        void interactAgents( AC&, MultiFab&) override {
+            amrex::Abort("Do not use this interface for this interaction model");
+        }
 
         /*! \brief Simulate agent interaction for random travel */
         void interactAgents( AC&, MultiFab&, AC&) override ;

--- a/src/InteractionModRandom.H
+++ b/src/InteractionModRandom.H
@@ -76,10 +76,10 @@ class InteractionModRandom : public InteractionModel<AC,ACT,ACTD,A>
         virtual ~InteractionModRandom() = default;
 
         /*! \brief Simulate agent interaction for random travel */
-        void interactAgents( AC&, MultiFab&) {}
+        void interactAgents( AC&, MultiFab&) override {}
 
         /*! \brief Simulate agent interaction for random travel */
-        void interactAgents( AC&, MultiFab&, AC&);
+        void interactAgents( AC&, MultiFab&, AC&) override ;
 
     protected:
 
@@ -183,7 +183,7 @@ void InteractionModRandom<AC,ACT,ACTD,A>::interactAgents(AC& a_agents, /*!< Agen
                     if ( notSusceptible<ACTD>(i, ptd, d) )  { return; }
 
                     //Real i_mask = mask_arr(home_i_ptr[i], home_j_ptr[i], 0);
-                    for (unsigned int jj = cell_start; jj < cell_stop; ++jj) {
+                    for (auto jj = cell_start; jj < cell_stop; ++jj) {
 
                         auto j = travel_inds[jj];
                         AMREX_ALWAYS_ASSERT( (Long) j < np);
@@ -247,7 +247,7 @@ void InteractionModRandom<AC,ACT,ACTD,A>::interactAgents(AC& a_agents, /*!< Agen
                     if ( notSusceptible<ACTD>(i, ptd, d) )  { return; }
 
                     //Real i_mask = mask_arr(home_i_ptr[i], home_j_ptr[i], 0);
-                    for (unsigned int jj = cell_start; jj < cell_stop; ++jj) {
+                    for (auto jj = cell_start; jj < cell_stop; ++jj) {
 
                         auto j = inds[jj];
                         AMREX_ALWAYS_ASSERT( (Long) j < np);

--- a/src/InteractionModRandom.H
+++ b/src/InteractionModRandom.H
@@ -141,9 +141,7 @@ void InteractionModRandom<AC,ACT,ACTD,A>::interactAgents(AC& a_agents, /*!< Agen
                 //auto mask_arr = a_mask[mfi].array();
                 auto lparm = a_agents.getDiseaseParameters_d(d);
 
-                ParallelForRNG( bins_ptr->numItems(),
-                                [=] AMREX_GPU_DEVICE (int ii, RandomEngine const& /*engine*/)
-                                noexcept
+                ParallelFor( bins_ptr->numItems(), [=] AMREX_GPU_DEVICE (int ii) noexcept
                 {
                     auto i = inds[ii];
                     int i_cell = binner(pstruct_ptr[i]);
@@ -205,9 +203,7 @@ void InteractionModRandom<AC,ACT,ACTD,A>::interactAgents(AC& a_agents, /*!< Agen
                 //auto mask_arr = a_mask[mfi].array();
                 auto lparm = a_agents.getDiseaseParameters_d(d);
 
-                ParallelForRNG( travel_bins_ptr->numItems(),
-                                [=] AMREX_GPU_DEVICE (int ii, RandomEngine const& /*engine*/)
-                                noexcept
+                ParallelFor( travel_bins_ptr->numItems(), [=] AMREX_GPU_DEVICE (int ii) noexcept
                 {
                     auto i = travel_inds[ii];
                     int i_cell = binner(pstruct_ptr[i]);

--- a/src/InteractionModRandom.H
+++ b/src/InteractionModRandom.H
@@ -160,7 +160,6 @@ void InteractionModRandom<AC,ACT,ACTD,A>::interactAgents(AC& a_agents, /*!< Agen
             AMREX_ALWAYS_ASSERT(bins_ptr->numBins() >= 0);
             AMREX_ALWAYS_ASSERT(travel_bins_ptr->numBins() >= 0);
             auto inds = bins_ptr->permutationPtr();
-            auto offsets = bins_ptr->offsetsPtr();
             auto travel_inds = travel_bins_ptr->permutationPtr();
             auto travel_offsets = travel_bins_ptr->offsetsPtr();
 
@@ -227,7 +226,6 @@ void InteractionModRandom<AC,ACT,ACTD,A>::interactAgents(AC& a_agents, /*!< Agen
             auto inds = bins_ptr->permutationPtr();
             auto offsets = bins_ptr->offsetsPtr();
             auto travel_inds = travel_bins_ptr->permutationPtr();
-            auto travel_offsets = travel_bins_ptr->offsetsPtr();
 
             for (int d = 0; d < n_disease; d++) {
 

--- a/src/InteractionModRandom.H
+++ b/src/InteractionModRandom.H
@@ -1,0 +1,274 @@
+/*! @file InteractionModRandom.H
+ * \brief Contains the class describing agent interactions for random travel
+ */
+
+#ifndef _INTERACTION_MOD_RANDOM_H_
+#define _INTERACTION_MOD_RANDOM_H_
+
+#include "InteractionModel.H"
+#include "DiseaseParm.H"
+#include "AgentDefinitions.H"
+
+using namespace amrex;
+
+/*! \brief One-on-one interaction between an infectious agent and a susceptible agent.
+ *
+ * This function defines the one-on-one interaction between an infectious agent and a
+ * susceptible agent on random travel. */
+template <typename PTDType>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+static void binaryInteractionRandom ( const int a_i, /*!< Index of infectious agent */
+                                      const int a_j, /*!< Index of susceptible agent */
+                                      const PTDType& a_ptd_i, /*!< Particle tile data for infectious agent */
+                                      const PTDType& a_ptd_j, /*!< Particle tile data for susceptible agent*/
+                                      const DiseaseParm* const a_lparm,  /*!< disease paramters */
+                                      const Real a_social_scale, /*!< Social scale */
+                                      ParticleReal* const a_prob_ptr /*!< infection probability */)
+{
+    Real infect = a_lparm->infect;
+    infect *= a_lparm->vac_eff;
+
+    auto age_group_ptr_j = a_ptd_j.m_idata[IntIdx::age_group];
+    auto nborhood_ptr_i = a_ptd_i.m_idata[IntIdx::nborhood];
+    auto nborhood_ptr_j = a_ptd_j.m_idata[IntIdx::nborhood];
+    auto school_ptr_i = a_ptd_i.m_idata[IntIdx::school];
+    auto withdrawn_ptr_i = a_ptd_i.m_idata[IntIdx::withdrawn];
+    auto withdrawn_ptr_j = a_ptd_j.m_idata[IntIdx::withdrawn];
+    if (withdrawn_ptr_i[a_i] || withdrawn_ptr_j[a_j]) { return; }
+    auto random_travel_ptr_i = a_ptd_i.m_idata[IntIdx::random_travel];
+    auto random_travel_ptr_j = a_ptd_j.m_idata[IntIdx::random_travel];
+    if (random_travel_ptr_i[a_i] || random_travel_ptr_j[a_j]) {return;}
+
+    //infect *= i_mask;
+    //infect *= j_mask;
+    ParticleReal prob = 1.0_prt;
+
+    // school < 0 means a child normally attends school, but not today
+    /* Should always be in the same community = same cell */
+    if (school_ptr_i[a_i] < 0) {  // not attending school, use _SC contacts
+        prob *= 1.0_prt - infect * a_lparm->xmit_comm_SC[age_group_ptr_j[a_j]] * a_social_scale;
+    } else {
+        prob *= 1.0_prt - infect * a_lparm->xmit_comm[age_group_ptr_j[a_j]] * a_social_scale;
+    }
+    // /* Neighborhood? */
+    if (nborhood_ptr_i[a_i] == nborhood_ptr_j[a_j]) {
+        if (school_ptr_i[a_i] < 0)  {
+            // not attending school, use _SC contacts
+            prob *= 1.0_prt - infect * a_lparm->xmit_hood_SC[age_group_ptr_j[a_j]] * a_social_scale;
+        } else {
+            prob *= 1.0_prt - infect * a_lparm->xmit_hood[age_group_ptr_j[a_j]] * a_social_scale;
+        }
+    }
+
+    Gpu::Atomic::Multiply(&a_prob_ptr[a_j], prob);
+}
+
+/*! \brief Class describing agent interactions for random travel */
+template <typename AC, typename ACT, typename ACTD, typename A>
+class InteractionModRandom : public InteractionModel<AC,ACT,ACTD,A>
+{
+    public:
+
+        /*! \brief null constructor */
+        InteractionModRandom() { }
+
+        /*! \brief default destructor */
+        virtual ~InteractionModRandom() = default;
+
+        /*! \brief Simulate agent interaction for random travel */
+        void interactAgents( AC&, MultiFab&) {};
+
+        /*! \brief Simulate agent interaction for random travel */
+        void interactAgents( AC&, MultiFab&, AC&);
+
+    protected:
+
+    private:
+};
+
+/*! Simulate the interactions between agents at home and compute
+    the infection probability for each agent:
+
+    + Create bins of agents if not already created (see
+      #amrex::GetParticleBin, #amrex::DenseBins):
+      + The bin size is 1 cell
+      + #amrex::GetParticleBin maps a particle to its bin index
+      + amrex::DenseBins::build() creates the bin-sorted array of particle indices and
+        the offset array for each bin (where the offset of a bin is its starting location
+        in the bin-sorted array of particle indices).
+
+    + For each agent *i* in the bin-sorted array of agents:
+      + Find its bin and the range of indices in the bin-sorted array for agents in its bin
+      + If the agent is #Status::immune, do nothing.
+      + If the agent is #Status::infected with the number of days infected (RealIdxDisease::disease_counter)
+        less than the incubation length, do nothing.
+      + Else, for each agent *j* in the same bin:
+        + If the agent is #Status::immune, do nothing.
+        + If the agent is #Status::infected with the number of days infected (RealIdxDisease::disease_counter)
+          less than the incubation length, do nothing.
+        + Else if *i* is not infected and *j* is infected, compute probability of *i* getting infected
+          from *j* (see below).
+
+    Summary of how the probability of agent A getting infected from agent B is computed:
+    + Compute infection probability reduction factor from vaccine efficacy (#DiseaseParm::vac_eff)
+    + Within family - if their IntIdx::nborhood and IntIdx::family indices are same,
+      and the agents are at home:
+      + If B is a child, use the appropriate transmission probability (#DiseaseParm::xmit_child_SC or
+        #DiseaseParm::xmit_child) depending on whether B goes to school or not (#IntIdx::school)
+      + If B is an adult, use the appropriate transmission probability (#DiseaseParm::xmit_adult_SC or
+        #DiseaseParm::xmit_adult) depending on whether B works at a school or not (#IntIdx::school)
+*/
+template <typename AC, typename ACT, typename ACTD, typename A>
+void InteractionModRandom<AC,ACT,ACTD,A>::interactAgents(AC& a_agents, /*!< Agent container */
+                                                         MultiFab& /*a_mask*/, /*!< Masking behavior */
+                                                         AC& a_on_random_travel)
+{
+    BL_PROFILE("InteractionModRandom::interactAgents");
+    int n_disease = a_agents.numDiseases();
+
+    IntVect bin_size = {AMREX_D_DECL(1, 1, 1)};
+    for (int lev = 0; lev < a_agents.numLevels(); ++lev)
+    {
+        const Geometry& geom = a_agents.Geom(lev);
+        const auto dxi = geom.InvCellSizeArray();
+        const auto plo = geom.ProbLoArray();
+        const auto domain = geom.Domain();
+
+        this->makeBins( a_agents, bin_size, lev, ExaEpi::InteractionNames::home );
+        this->makeBins( a_on_random_travel, bin_size, lev, ExaEpi::InteractionNames::random );
+
+        // we make two passes here, in the first case, agents on random travel infect local agents
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        for(MFIter mfi = a_agents.MakeMFIter(lev, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
+            auto pair_ind = std::make_pair(mfi.index(), mfi.LocalTileIndex());
+            auto bins_ptr = a_agents.getBins(pair_ind, ExaEpi::InteractionNames::home);
+            auto travel_bins_ptr = a_on_random_travel.getBins(pair_ind, ExaEpi::InteractionNames::random);
+
+            auto& ptile = a_agents.ParticlesAt(lev, mfi);
+            const auto& ptd = ptile.getParticleTileData();
+            auto& travel_ptile = a_on_random_travel.ParticlesAt(lev, mfi);
+            const auto& travel_ptd = travel_ptile.getParticleTileData();
+
+            auto& aos   = ptile.GetArrayOfStructs();
+            const auto np = aos.numParticles();
+            auto pstruct_ptr = aos().dataPtr();
+
+            auto binner = GetParticleBin{plo, dxi, domain, bin_size, mfi.validbox()};
+            AMREX_ALWAYS_ASSERT(bins_ptr->numBins() >= 0);
+            AMREX_ALWAYS_ASSERT(travel_bins_ptr->numBins() >= 0);
+            auto inds = bins_ptr->permutationPtr();
+            auto offsets = bins_ptr->offsetsPtr();
+            auto travel_inds = travel_bins_ptr->permutationPtr();
+            auto travel_offsets = travel_bins_ptr->offsetsPtr();
+
+            for (int d = 0; d < n_disease; d++) {
+
+                auto prob_ptr = this->getAgentProbPtr(a_agents,lev,mfi,d);
+                //auto mask_arr = a_mask[mfi].array();
+                auto lparm = a_agents.getDiseaseParameters_d(d);
+
+                ParallelForRNG( bins_ptr->numItems(),
+                                [=] AMREX_GPU_DEVICE (int ii, RandomEngine const& /*engine*/)
+                                noexcept
+                {
+                    auto i = inds[ii];
+                    int i_cell = binner(pstruct_ptr[i]);
+                    auto cell_start = travel_offsets[i_cell];
+                    auto cell_stop  = travel_offsets[i_cell+1];
+
+                    AMREX_ALWAYS_ASSERT( (Long) i < np);
+
+                    if ( notSusceptible<ACTD>(i, ptd, d) )  { return; }
+
+                    //Real i_mask = mask_arr(home_i_ptr[i], home_j_ptr[i], 0);
+                    for (unsigned int jj = cell_start; jj < cell_stop; ++jj) {
+
+                        auto j = travel_inds[jj];
+                        AMREX_ALWAYS_ASSERT( (Long) j < np);
+
+                        //Real j_mask = mask_arr(home_i_ptr[j], home_j_ptr[j], 0);
+                        //if (i == j) continue;
+
+                        if ( isInfectious<ACTD>(j, travel_ptd, d) ) {
+                            Real social_scale = 1.0_prt;  // TODO this should vary based on cell
+                            binaryInteractionRandom<ACTD>( j, i, travel_ptd, ptd, lparm, social_scale, prob_ptr );
+                        }
+                    }
+                });
+                Gpu::synchronize();
+            }
+        }
+
+        // now, the local agents infect the ones on travel
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        for(MFIter mfi = a_agents.MakeMFIter(lev, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
+            auto pair_ind = std::make_pair(mfi.index(), mfi.LocalTileIndex());
+            auto bins_ptr = a_agents.getBins(pair_ind, ExaEpi::InteractionNames::home);
+            auto travel_bins_ptr = a_on_random_travel.getBins(pair_ind, ExaEpi::InteractionNames::random);
+
+            auto& ptile = a_agents.ParticlesAt(lev, mfi);
+            const auto& ptd = ptile.getParticleTileData();
+            auto& travel_ptile = a_on_random_travel.ParticlesAt(lev, mfi);
+            const auto& travel_ptd = travel_ptile.getParticleTileData();
+
+            auto& aos   = ptile.GetArrayOfStructs();
+            const auto np = aos.numParticles();
+            auto pstruct_ptr = aos().dataPtr();
+
+            auto binner = GetParticleBin{plo, dxi, domain, bin_size, mfi.validbox()};
+            AMREX_ALWAYS_ASSERT(bins_ptr->numBins() >= 0);
+            AMREX_ALWAYS_ASSERT(travel_bins_ptr->numBins() >= 0);
+            auto inds = bins_ptr->permutationPtr();
+            auto offsets = bins_ptr->offsetsPtr();
+            auto travel_inds = travel_bins_ptr->permutationPtr();
+            auto travel_offsets = travel_bins_ptr->offsetsPtr();
+
+            for (int d = 0; d < n_disease; d++) {
+
+                auto prob_ptr = this->getAgentProbPtr(a_on_random_travel,lev,mfi,d);
+                //auto mask_arr = a_mask[mfi].array();
+                auto lparm = a_agents.getDiseaseParameters_d(d);
+
+                ParallelForRNG( travel_bins_ptr->numItems(),
+                                [=] AMREX_GPU_DEVICE (int ii, RandomEngine const& /*engine*/)
+                                noexcept
+                {
+                    auto i = travel_inds[ii];
+                    int i_cell = binner(pstruct_ptr[i]);
+                    auto cell_start = offsets[i_cell];
+                    auto cell_stop  = offsets[i_cell+1];
+
+                    AMREX_ALWAYS_ASSERT( (Long) i < np);
+
+                    if ( notSusceptible<ACTD>(i, ptd, d) )  { return; }
+
+                    //Real i_mask = mask_arr(home_i_ptr[i], home_j_ptr[i], 0);
+                    for (unsigned int jj = cell_start; jj < cell_stop; ++jj) {
+
+                        auto j = inds[jj];
+                        AMREX_ALWAYS_ASSERT( (Long) j < np);
+
+                        //Real j_mask = mask_arr(home_i_ptr[j], home_j_ptr[j], 0);
+                        //if (i == j) continue;
+
+                        if ( isInfectious<ACTD>(j, ptd, d) ) {
+                            Real social_scale = 1.0_prt;  // TODO this should vary based on cell
+                            binaryInteractionRandom<ACTD>( j, i, ptd, travel_ptd, lparm, social_scale, prob_ptr );
+                        }
+                    }
+                });
+                Gpu::synchronize();
+            }
+        }
+
+
+    }
+}
+
+#endif

--- a/src/InteractionModSchool.H
+++ b/src/InteractionModSchool.H
@@ -84,7 +84,7 @@ class InteractionModSchool : public InteractionModel<AC,ACT,ACTD,A>
         virtual void interactAgents( AC&, MultiFab& );
 
         /*! \brief Simulate agent interaction at school */
-        virtual void interactAgents( AC&, MultiFab&, AC& ) {};
+        virtual void interactAgents( AC&, MultiFab&, AC& ) {}
 
     protected:
 

--- a/src/InteractionModSchool.H
+++ b/src/InteractionModSchool.H
@@ -30,8 +30,9 @@ static void binaryInteractionSchool ( const int a_i, /*!< Index of infectious ag
     auto nborhood_ptr = a_ptd.m_idata[IntIdx::nborhood];
     auto school_ptr = a_ptd.m_idata[IntIdx::school];
     auto withdrawn_ptr = a_ptd.m_idata[IntIdx::withdrawn];
-
     if (withdrawn_ptr[a_i] || withdrawn_ptr[a_j]) { return; }
+    auto random_travel_ptr = a_ptd.m_idata[IntIdx::random_travel];
+    if (random_travel_ptr[a_i] || random_travel_ptr[a_j]) {return;}
 
     //infect *= i_mask;
     //infect *= j_mask;
@@ -78,6 +79,9 @@ class InteractionModSchool : public InteractionModel<AC,ACT,ACTD,A>
 
         /*! \brief Simulate agent interaction at school */
         virtual void interactAgents( AC&, MultiFab& );
+
+        /*! \brief Simulate agent interaction at school */
+        virtual void interactAgents( AC&, MultiFab&, AC& ) {};
 
     protected:
 

--- a/src/InteractionModSchool.H
+++ b/src/InteractionModSchool.H
@@ -84,7 +84,7 @@ class InteractionModSchool : public InteractionModel<AC,ACT,ACTD,A>
         virtual void interactAgents( AC&, MultiFab& ) override;
 
         /*! \brief Simulate agent interaction at school */
-        virtual void interactAgents( AC&, MultiFab&, AC& ) {}
+        virtual void interactAgents( AC&, MultiFab&, AC& ) override {}
 
     protected:
 

--- a/src/InteractionModSchool.H
+++ b/src/InteractionModSchool.H
@@ -32,7 +32,7 @@ static void binaryInteractionSchool ( const int a_i, /*!< Index of infectious ag
     auto withdrawn_ptr = a_ptd.m_idata[IntIdx::withdrawn];
     if (withdrawn_ptr[a_i] || withdrawn_ptr[a_j]) { return; }
     auto random_travel_ptr = a_ptd.m_idata[IntIdx::random_travel];
-    if (random_travel_ptr[a_i] || random_travel_ptr[a_j]) {return;}
+    if ((random_travel_ptr[a_i] >= 0) || (random_travel_ptr[a_j] >= 0)) {return;}
 
     //infect *= i_mask;
     //infect *= j_mask;

--- a/src/InteractionModSchool.H
+++ b/src/InteractionModSchool.H
@@ -84,7 +84,9 @@ class InteractionModSchool : public InteractionModel<AC,ACT,ACTD,A>
         virtual void interactAgents( AC&, MultiFab& ) override;
 
         /*! \brief Simulate agent interaction at school */
-        virtual void interactAgents( AC&, MultiFab&, AC& ) override {}
+        virtual void interactAgents( AC&, MultiFab&, AC& ) override {
+            amrex::Abort("Do not use this interface for this interaction model");
+        }
 
     protected:
 

--- a/src/InteractionModWork.H
+++ b/src/InteractionModWork.H
@@ -65,7 +65,7 @@ class InteractionModWork : public InteractionModel<AC,ACT,ACTD,A>
         virtual void interactAgents( AC&, MultiFab& ) override;
 
         /*! \brief Simulate agent interaction at work */
-        virtual void interactAgents( AC&, MultiFab&, AC& ) {}
+        virtual void interactAgents( AC&, MultiFab&, AC& ) override {}
 
     protected:
 

--- a/src/InteractionModWork.H
+++ b/src/InteractionModWork.H
@@ -65,7 +65,9 @@ class InteractionModWork : public InteractionModel<AC,ACT,ACTD,A>
         virtual void interactAgents( AC&, MultiFab& ) override;
 
         /*! \brief Simulate agent interaction at work */
-        virtual void interactAgents( AC&, MultiFab&, AC& ) override {}
+        virtual void interactAgents( AC&, MultiFab&, AC& ) override {
+            amrex::Abort("Do not use this interface for this interaction model");
+        }
 
     protected:
 

--- a/src/InteractionModWork.H
+++ b/src/InteractionModWork.H
@@ -31,7 +31,7 @@ static void binaryInteractionWork ( const int a_i, /*!< Index of infectious agen
     auto withdrawn_ptr = a_ptd.m_idata[IntIdx::withdrawn];
     if (withdrawn_ptr[a_i] || withdrawn_ptr[a_j]) { return; }
     auto random_travel_ptr = a_ptd.m_idata[IntIdx::random_travel];
-    if (random_travel_ptr[a_i] || random_travel_ptr[a_j]) {return;}
+    if ((random_travel_ptr[a_i] >= 0) || (random_travel_ptr[a_j] >= 0)) {return;}
 
     //infect *= i_mask;
     //infect *= j_mask;

--- a/src/InteractionModWork.H
+++ b/src/InteractionModWork.H
@@ -29,8 +29,9 @@ static void binaryInteractionWork ( const int a_i, /*!< Index of infectious agen
     auto work_i_ptr = a_ptd.m_idata[IntIdx::work_i];
     auto workgroup_ptr = a_ptd.m_idata[IntIdx::workgroup];
     auto withdrawn_ptr = a_ptd.m_idata[IntIdx::withdrawn];
-
     if (withdrawn_ptr[a_i] || withdrawn_ptr[a_j]) { return; }
+    auto random_travel_ptr = a_ptd.m_idata[IntIdx::random_travel];
+    if (random_travel_ptr[a_i] || random_travel_ptr[a_j]) {return;}
 
     //infect *= i_mask;
     //infect *= j_mask;
@@ -60,6 +61,9 @@ class InteractionModWork : public InteractionModel<AC,ACT,ACTD,A>
 
         /*! \brief Simulate agent interaction at work */
         virtual void interactAgents( AC&, MultiFab& );
+
+        /*! \brief Simulate agent interaction at work */
+        virtual void interactAgents( AC&, MultiFab&, AC& ) {};
 
     protected:
 

--- a/src/InteractionModWork.H
+++ b/src/InteractionModWork.H
@@ -65,7 +65,7 @@ class InteractionModWork : public InteractionModel<AC,ACT,ACTD,A>
         virtual void interactAgents( AC&, MultiFab& );
 
         /*! \brief Simulate agent interaction at work */
-        virtual void interactAgents( AC&, MultiFab&, AC& ) {};
+        virtual void interactAgents( AC&, MultiFab&, AC& ) {}
 
     protected:
 

--- a/src/InteractionModel.H
+++ b/src/InteractionModel.H
@@ -29,6 +29,7 @@ namespace ExaEpi
         const std::string school = "school";
         const std::string nborhood = "neighborhood";
         const std::string transit = "transit";
+        const std::string random = "random";
     }
 }
 
@@ -56,6 +57,9 @@ class InteractionModel
 
         /*! \brief Interact agents for a model */
         virtual void interactAgents(AC&, MultiFab&) = 0;
+
+        /*! \brief Interact agents for a model */
+        virtual void interactAgents(AC&, MultiFab&, AC&) = 0;
 
     protected:
 

--- a/src/InteractionModelLibrary.H
+++ b/src/InteractionModelLibrary.H
@@ -8,6 +8,7 @@
 #include "InteractionModGeneric.H"
 #include "InteractionModHome.H"
 #include "InteractionModNborhood.H"
+#include "InteractionModRandom.H"
 #include "InteractionModSchool.H"
 #include "InteractionModWork.H"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -383,14 +383,17 @@ void runAgent ()
             pc.interactNight(mask_behavior);
 
             if (params.random_travel_int > 0) {
-            pc.interactRandomTravel(mask_behavior, on_travel_pc);
+                pc.interactRandomTravel(mask_behavior, on_travel_pc);
             }
 
             // Infect agents based on their interactions
             pc.infectAgents();
 
             if (params.random_travel_int > 0) {
+                on_travel_pc.moveAgentsToHome();
+                on_travel_pc.Redistribute();
                 pc.returnRandomTravel(on_travel_pc);
+                on_travel_pc.clearParticles();
             }
 
             cur_time += 1.0_rt; // time step is one day

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -383,14 +383,14 @@ void runAgent ()
             pc.interactNight(mask_behavior);
 
             if (params.random_travel_int > 0) {
-                pc.interactRandomTravel(mask_behavior, on_travel_pc);
+            pc.interactRandomTravel(mask_behavior, on_travel_pc);
             }
 
             // Infect agents based on their interactions
             pc.infectAgents();
 
             if (params.random_travel_int > 0) {
-                pc.returnRandomTravel();
+                pc.returnRandomTravel(on_travel_pc);
             }
 
             cur_time += 1.0_rt; // time step is one day

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -367,12 +367,12 @@ void runAgent ()
             }
 
             if ((params.random_travel_int > 0) && (i % params.random_travel_int == 0)) {
-                    pc.moveRandomTravel(unit_mf);
-                    using SrcData = AgentContainer::ParticleTileType::ConstParticleTileDataType;
-                    on_travel_pc.copyParticles(pc,
-                                               [=] AMREX_GPU_HOST_DEVICE (const SrcData& src, int ip) {
-                                                   return (src.m_idata[IntIdx::random_travel][ip] >= 0);
-                                               });
+                pc.moveRandomTravel(unit_mf);
+                using SrcData = AgentContainer::ParticleTileType::ConstParticleTileDataType;
+                on_travel_pc.copyParticles(pc,
+                                           [=] AMREX_GPU_HOST_DEVICE (const SrcData& src, int ip) {
+                                               return (src.m_idata[IntIdx::random_travel][ip] >= 0);
+                                           });
             }
 
             // Typical day
@@ -382,14 +382,14 @@ void runAgent ()
             pc.interactEvening(mask_behavior);
             pc.interactNight(mask_behavior);
 
-            if (params.random_travel_int > 0) {
+            if ((params.random_travel_int > 0) && (i % params.random_travel_int == 0)) {
                 pc.interactRandomTravel(mask_behavior, on_travel_pc);
             }
 
             // Infect agents based on their interactions
             pc.infectAgents();
 
-            if (params.random_travel_int > 0) {
+            if ((params.random_travel_int > 0) && (i % params.random_travel_int == 0)) {
                 on_travel_pc.moveAgentsToHome();
                 on_travel_pc.Redistribute();
                 pc.returnRandomTravel(on_travel_pc);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -371,9 +371,8 @@ void runAgent ()
                     using SrcData = AgentContainer::ParticleTileType::ConstParticleTileDataType;
                     on_travel_pc.copyParticles(pc,
                                                [=] AMREX_GPU_HOST_DEVICE (const SrcData& src, int ip) {
-                                                   return src.m_idata[IntIdx::random_travel][ip];
+                                                   return (src.m_idata[IntIdx::random_travel][ip] >= 0);
                                                });
-                    amrex::Print() << "Selected " << on_travel_pc.TotalNumberOfParticles() << " for random travel. \n";
             }
 
             // Typical day


### PR DESCRIPTION
This is the same run with random travel versus without: 

![random_travel](https://github.com/user-attachments/assets/31700fa8-a5aa-4371-bd65-ea4ae9af4b5e)

The time spent doing redistribution was small, about 1% of the run total time.
