### PR TITLE
Add HDF5 documentation to readthedocs

### DIFF
--- a/docs/source/install/cmake.rst
+++ b/docs/source/install/cmake.rst
@@ -60,6 +60,7 @@ or by adding arguments with ``-D<OPTION>=<VALUE>`` to the first CMake call, e.g.
    cmake -S . -B build -DAMReX_GPU_BACKEND=CUDA -DAMReX_HDF5=TRUE
 
 Some of the options available are:
-- `-DAMReX_GPU_BACKEND=CUDA`: to build with GPU support.
-- `-DAMReX_HDF5=TRUE`: to write output as (compressed) HDF5. Parallel HDF5 is required, and the HDF5_CHUNK_SIZE environment variable
-should be set to a reasonable number before running the compiled code; 100,000 is recommended.
+
+- ``-DAMReX_GPU_BACKEND=CUDA``: to build with GPU support.
+
+- ``-DAMReX_HDF5=TRUE``: to write output as (compressed) HDF5. Parallel HDF5 is required, and the `HDF5_CHUNK_SIZE` environment variable should be set to a reasonable number before running the compiled code; 100,000 is recommended. For example, run ``export HDF5_CHUNK_SIZE=100000`` before running the agent.

--- a/docs/source/install/cmake.rst
+++ b/docs/source/install/cmake.rst
@@ -57,4 +57,9 @@ or by adding arguments with ``-D<OPTION>=<VALUE>`` to the first CMake call, e.g.
 
 .. code-block:: bash
 
-   cmake -S . -B build -DAMReX_GPU_BACKEND=CUDA
+   cmake -S . -B build -DAMReX_GPU_BACKEND=CUDA -DAMReX_HDF5=TRUE
+
+Some of the options available are:
+- `-DAMReX_GPU_BACKEND=CUDA`: to build with GPU support.
+- `-DAMReX_HDF5=TRUE`: to write output as (compressed) HDF5. Parallel HDF5 is required, and the HDF5_CHUNK_SIZE environment variable
+should be set to a reasonable number before running the compiled code; 100,000 is recommended.

--- a/docs/source/install/dependencies.rst
+++ b/docs/source/install/dependencies.rst
@@ -18,3 +18,5 @@ Optional dependencies include:
 - `OpenMP 3.1+ <https://www.openmp.org>`__: for threaded CPU execution
 - `CCache <https://ccache.dev>`__: to speed up rebuilds (needs 3.7.9+ for CUDA)
 - `Ninja <https://ninja-build.org>`__: for faster parallel compiles
+- `Parallel HDF5 <https://github.com/HDFGroup/hdf5>`__: to write to HDF5. Parallel HDF5 is required, and modules with pre-built Parallel HDF5 installations are 
+available on most HPC machines.


### PR DESCRIPTION
Include HDF5 as an optional dependency and explicitly mention the -DAMReX_HDF5 flag in the readthedocs. Not 100% sure about the placement of the flag explanations, but this seemed reasonable. 