### PR TITLE
Add script to generate population-time matrix

### DIFF
--- a/utilities/travel_model_scripts.py
+++ b/utilities/travel_model_scripts.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pandas as pd
+from hdf5_process import get_home_and_work_counties
+
+def get_cross_table(data_dir: str):
+    """Returns a pandas DataFrame with the agent time matrix,
+    representing the fraction of time the population from a home county
+    spends in each other county, in aggregate"""
+
+    # Gets a list of home/work counties for each particle as a 2xN array
+    # (home as first row, work as second row)
+    # and a list of all counties.
+    particles, counties = get_home_and_work_counties(data_dir)
+
+    # Create a table of counts of particles from a given home who work
+    # at a given county 
+    table = pd.pivot_table(pd.DataFrame(particles.T, columns=['home', 'outside county']),
+                           index = 'outside county', columns = 'home', aggfunc = len, fill_value=0)
+
+    # Normalize the table, then average with identity matrix to represent
+    # agents spending half their time at home.
+    return (table / table.sum() + np.eye(table.shape[0])) / 2
+
+def main():
+    table = get_cross_table("/pscratch/sd/a/arnav/ganning/sim/180_run")
+    print(table)
+
+if __name__ == "__main__":
+    main()

--- a/utilities/travel_model_scripts.py
+++ b/utilities/travel_model_scripts.py
@@ -13,7 +13,7 @@ def get_cross_table(data_dir: str):
     particles, counties = get_home_and_work_counties(data_dir)
 
     # Create a table of counts of particles from a given home who work
-    # at a given county 
+    # at a given county
     table = pd.pivot_table(pd.DataFrame(particles.T, columns=['home', 'outside county']),
                            index = 'outside county', columns = 'home', aggfunc = len, fill_value=0)
 


### PR DESCRIPTION
For fitting with Mahtab's model, requested by @tannguyen153. Assumes that each agent spends half their time in their home county and half in their work county.

Runs on day 0 output of ExaEpi and uses HDF5 processing scripts, so needs HDF5 output. 
If this is something that shouldn't go in the repo and I should just send over Slack, let me know.

Output is a pandas DataFrame, with each column representing average distribution of time spent for a given home county:
<img width="725" alt="image" src="https://github.com/user-attachments/assets/6cb5b5d5-c264-46e1-9549-8f7b5227f337">
