### PR TITLE
Fix out-of-bounds access for non-local communities in random travel

### DIFF
--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -862,7 +862,6 @@ void AgentContainer::moveRandomTravel (const iMultiFab& unit_mf)
 #endif
         for(MFIter mfi = MakeMFIter(lev, TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
-            const auto unit_arr = unit_mf[mfi].array();
             int gid = mfi.index();
             int tid = mfi.LocalTileIndex();
             auto& ptile = plev[std::make_pair(gid, tid)];

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -882,14 +882,10 @@ void AgentContainer::moveRandomTravel (const iMultiFab& unit_mf)
                     if (withdrawn_ptr[i] == 1) {return ;}
                     if (amrex::Random(engine) < 0.0001) {
                         random_travel_ptr[i] = i;
-                        int random_unit = -1;
-                        while (random_unit == -1) {
-                            int i_random = int( amrex::Real(i_max)*amrex::Random(engine));
-                            int j_random = int( amrex::Real(j_max)*amrex::Random(engine));
-                            p.pos(0) = i_random;
-                            p.pos(1) = j_random;
-                            random_unit = unit_arr(i_random, j_random, 0);
-                        }
+                        int i_random = int( amrex::Real(i_max)*amrex::Random(engine));
+                        int j_random = int( amrex::Real(j_max)*amrex::Random(engine));
+                        p.pos(0) = i_random;
+                        p.pos(1) = j_random;
                     }
                 }
             });


### PR DESCRIPTION
This code assumed we could access any community in the domain to query the number of people. However, this is not true with domain decomposition. We could fix this by adding a parallel reduction and iterating until no empty units have been selected. However, I don't think this is really needed - the small number of agents who travel to unpopulated communities just won't contribute to spread that time step.