### PR TITLE
Fix Disease Status

### DIFF
--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -677,8 +677,8 @@ void AgentContainer::infectAgents ()
                             if (latent_period_ptr[i] < 0) { latent_period_ptr[i] = 0.0_rt; }
                             if (infectious_period_ptr[i] < 0) { infectious_period_ptr[i] = 0.0_rt; }
                             if (incubation_period_ptr[i] < 0) { incubation_period_ptr[i] = 0.0_rt; }
-                            if (latent_period_ptr[i] > (infectious_period_ptr[i]+incubation_period_ptr[i])) {
-                                latent_period_ptr[i] = std::floor(infectious_period_ptr[i]+incubation_period_ptr[i]);
+                            if (incubation_period_ptr[i] > (infectious_period_ptr[i]+latent_period_ptr[i])) {
+                                incubation_period_ptr[i] = std::floor(infectious_period_ptr[i]+latent_period_ptr[i]);
                             }
                             return;
                         }

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -671,11 +671,11 @@ void AgentContainer::infectAgents ()
                         if (amrex::Random(engine) < prob_ptr[i]) {
                             status_ptr[i] = Status::infected;
                             counter_ptr[i] = 0.0_rt;
-                            latent_period_ptr[i]     = std::max(0.0_rt,amrex::RandomNormal(lparm->latent_length_mean,     lparm->latent_length_std,     engine));
-                            infectious_period_ptr[i] = std::max(0.0_rt,amrex::RandomNormal(lparm->infectious_length_mean, lparm->infectious_length_std, engine));
-                            incubation_period_ptr[i] = std::max(0.0_rt,amrex::RandomNormal(lparm->incubation_length_mean, lparm->incubation_length_std, engine));
-                            while ((latent_period_ptr[i] > (infectious_period_ptr[i]+incubation_period_ptr[i]))) {
-                                latent_period_ptr[i] -= std::min(0.5_rt,latent_period_ptr[i]);
+                            latent_period_ptr[i]     = std::max(amrex::ParticleReal(0.0),amrex::RandomNormal(lparm->latent_length_mean,     lparm->latent_length_std,     engine));
+                            infectious_period_ptr[i] = std::max(amrex::ParticleReal(0.0),amrex::RandomNormal(lparm->infectious_length_mean, lparm->infectious_length_std, engine));
+                            incubation_period_ptr[i] = std::max(amrex::ParticleReal(0.0),amrex::RandomNormal(lparm->incubation_length_mean, lparm->incubation_length_std, engine));
+                            if (latent_period_ptr[i] > (infectious_period_ptr[i]+incubation_period_ptr[i])) {
+                                latent_period_ptr[i] = std::floor(infectious_period_ptr[i]+incubation_period_ptr[i]);
                             }
                             return;
                         }

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -671,9 +671,12 @@ void AgentContainer::infectAgents ()
                         if (amrex::Random(engine) < prob_ptr[i]) {
                             status_ptr[i] = Status::infected;
                             counter_ptr[i] = 0.0_rt;
-                            latent_period_ptr[i]     = std::max(amrex::ParticleReal(0.0),amrex::RandomNormal(lparm->latent_length_mean,     lparm->latent_length_std,     engine));
-                            infectious_period_ptr[i] = std::max(amrex::ParticleReal(0.0),amrex::RandomNormal(lparm->infectious_length_mean, lparm->infectious_length_std, engine));
-                            incubation_period_ptr[i] = std::max(amrex::ParticleReal(0.0),amrex::RandomNormal(lparm->incubation_length_mean, lparm->incubation_length_std, engine));
+                            latent_period_ptr[i] = amrex::RandomNormal(lparm->latent_length_mean, lparm->latent_length_std, engine);
+                            infectious_period_ptr[i] = amrex::RandomNormal(lparm->infectious_length_mean, lparm->infectious_length_std, engine);
+                            incubation_period_ptr[i] = amrex::RandomNormal(lparm->incubation_length_mean, lparm->incubation_length_std, engine);
+                            if (latent_period_ptr[i] < 0) { latent_period_ptr[i] = 0.0_rt; }
+                            if (infectious_period_ptr[i] < 0) { infectious_period_ptr[i] = 0.0_rt; }
+                            if (incubation_period_ptr[i] < 0) { incubation_period_ptr[i] = 0.0_rt; }
                             if (latent_period_ptr[i] > (infectious_period_ptr[i]+incubation_period_ptr[i])) {
                                 latent_period_ptr[i] = std::floor(infectious_period_ptr[i]+incubation_period_ptr[i]);
                             }

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -174,7 +174,7 @@ void AgentContainer::moveAgentsToWork ()
             amrex::ParallelFor( np,
             [=] AMREX_GPU_DEVICE (int ip) noexcept
             {
-                if (!isHospitalized(ip, ptd)) {
+                if (!inHospital(ip, ptd)) {
                     ParticleType& p = pstruct[ip];
                     p.pos(0) = (work_i_ptr[ip] + 0.5_prt)*dx[0];
                     p.pos(1) = (work_j_ptr[ip] + 0.5_prt)*dx[1];
@@ -222,7 +222,7 @@ void AgentContainer::moveAgentsToHome ()
             amrex::ParallelFor( np,
             [=] AMREX_GPU_DEVICE (int ip) noexcept
             {
-                if (!isHospitalized(ip, ptd)) {
+                if (!inHospital(ip, ptd)) {
                     ParticleType& p = pstruct[ip];
                     p.pos(0) = (home_i_ptr[ip] + 0.5_prt) * dx[0];
                     p.pos(1) = (home_j_ptr[ip] + 0.5_prt) * dx[1];
@@ -269,7 +269,7 @@ void AgentContainer::moveRandomTravel (const amrex::Real random_travel_prob)
             amrex::ParallelForRNG( np,
             [=] AMREX_GPU_DEVICE (int i, RandomEngine const& engine) noexcept
             {
-                if (!isHospitalized(i, ptd) && !withdrawn_ptr[i]) {
+                if (!inHospital(i, ptd) && !withdrawn_ptr[i]) {
                     ParticleType& p = pstruct[i];
                     if (amrex::Random(engine) < random_travel_prob) {
                         random_travel_ptr[i] = i;
@@ -321,7 +321,7 @@ void AgentContainer::moveAirTravel (const iMultiFab& unit_mf, AirTravelFlow& air
             [=] AMREX_GPU_DEVICE (int i, RandomEngine const& engine) noexcept
             {
                 int unit = unit_arr(home_i_ptr[i], home_j_ptr[i], 0);
-                if (!isHospitalized(i, ptd) && random_travel_ptr[i] <0 && air_travel_ptr[i] <0) {
+                if (!inHospital(i, ptd) && random_travel_ptr[i] <0 && air_travel_ptr[i] <0) {
                     if (withdrawn_ptr[i] == 1) {return ;}
                     if (amrex::Random(engine) < air_travel_prob_ptr[unit]) {
                                 ParticleType& p = pstruct[i];
@@ -548,7 +548,7 @@ void AgentContainer::updateStatus ( MFPtrVec& a_disease_stats /*!< Community-wis
             amrex::ParallelFor( np,
             [=] AMREX_GPU_DEVICE (int ip) noexcept
             {
-                if (isHospitalized(ip, ptd)) {
+                if (inHospital(ip, ptd)) {
                     ParticleType& p = pstruct[ip];
                     p.pos(0) = (hosp_i_ptr[ip] + 0.5_prt)*dx[0];
                     p.pos(1) = (hosp_j_ptr[ip] + 0.5_prt)*dx[1];

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -671,9 +671,12 @@ void AgentContainer::infectAgents ()
                         if (amrex::Random(engine) < prob_ptr[i]) {
                             status_ptr[i] = Status::infected;
                             counter_ptr[i] = 0.0_rt;
-                            latent_period_ptr[i] = amrex::RandomNormal(lparm->latent_length_mean, lparm->latent_length_std, engine);
-                            infectious_period_ptr[i] = amrex::RandomNormal(lparm->infectious_length_mean, lparm->infectious_length_std, engine);
-                            incubation_period_ptr[i] = amrex::RandomNormal(lparm->incubation_length_mean, lparm->incubation_length_std, engine);
+                            latent_period_ptr[i]     = std::max(0.0_rt,amrex::RandomNormal(lparm->latent_length_mean,     lparm->latent_length_std,     engine));
+                            infectious_period_ptr[i] = std::max(0.0_rt,amrex::RandomNormal(lparm->infectious_length_mean, lparm->infectious_length_std, engine));
+                            incubation_period_ptr[i] = std::max(0.0_rt,amrex::RandomNormal(lparm->incubation_length_mean, lparm->incubation_length_std, engine));
+                            while ((latent_period_ptr[i] > (infectious_period_ptr[i]+incubation_period_ptr[i]))) {
+                                latent_period_ptr[i] -= std::min(0.5_rt,latent_period_ptr[i]);
+                            }
                             return;
                         }
                     }

--- a/src/AgentDefinitions.H
+++ b/src/AgentDefinitions.H
@@ -208,8 +208,8 @@ bool notSusceptible ( const int      a_idx, /*!< Agent index */
 /*! \brief Is an agent hospitalized? */
 template <typename PTDType>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-bool isHospitalized ( const int      a_idx, /*!< Agent index */
-                      const PTDType& a_ptd  /*!< Particle tile data */ )
+bool inHospital ( const int      a_idx, /*!< Agent index */
+                  const PTDType& a_ptd  /*!< Particle tile data */ )
 {
     return (   (a_ptd.m_idata[IntIdx::hosp_i][a_idx] >= 0)
             && (a_ptd.m_idata[IntIdx::hosp_j][a_idx] >= 0) );

--- a/src/DiseaseStatus.H
+++ b/src/DiseaseStatus.H
@@ -117,18 +117,18 @@ void DiseaseStatus<AC,ACT,ACTD,A>::updateAgents(AC& a_agents, /*!< Agent contain
             int i_RT = IntIdx::nattribs;
             int r_RT = RealIdx::nattribs;
 
-            Gpu::DeviceVector<int> flag_hosp, flag_ICU, flag_vent;
-            flag_hosp.resize(np);
-            flag_ICU.resize(np);
-            flag_vent.resize(np);
-            auto flag_hosp_ptr = flag_hosp.data();
-            auto flag_ICU_ptr = flag_ICU.data();
-            auto flag_vent_ptr = flag_vent.data();
+            Gpu::DeviceVector<int> marked_for_hosp, marked_for_ICU, marked_for_vent;
+            marked_for_hosp.resize(np);
+            marked_for_ICU.resize(np);
+            marked_for_vent.resize(np);
+            auto marked_for_hosp_ptr = marked_for_hosp.data();
+            auto marked_for_ICU_ptr = marked_for_ICU.data();
+            auto marked_for_vent_ptr = marked_for_vent.data();
             ParallelFor( np, [=] AMREX_GPU_DEVICE (int i) noexcept
             {
-                flag_hosp_ptr[i] = 0;
-                flag_ICU_ptr[i] = 0;
-                flag_vent_ptr[i] = 0;
+                marked_for_hosp_ptr[i] = 0;
+                marked_for_ICU_ptr[i] = 0;
+                marked_for_vent_ptr[i] = 0;
             });
             Gpu::synchronize();
 
@@ -186,21 +186,21 @@ void DiseaseStatus<AC,ACT,ACTD,A>::updateAgents(AC& a_agents, /*!< Agent contain
                             }
 
                             if (symptomatic_ptr[i] == SymptomStatus::symptomatic) {
-                                int flag_ICU_i = 0, flag_vent_i = 0;
+                                int marked_for_ICU_i = 0, marked_for_vent_i = 0;
                                 Real num_days = 0;
                                 disease_parm_d->check_hospitalization( num_days,
-                                                                       flag_ICU_i,
-                                                                       flag_vent_i,
+                                                                       marked_for_ICU_i,
+                                                                       marked_for_vent_i,
                                                                        age_group_ptr[i],
                                                                        u50frac,
                                                                        engine );
                                 timer_ptr[i] = ParticleReal(num_days);
-                                if (timer_ptr[i] > 0) { flag_hosp_ptr[i] = 1; }
-                                if (flag_ICU_i) { flag_ICU_ptr[i] = 1; }
-                                if (flag_vent_i) { flag_vent_ptr[i] = 1; }
+                                if (timer_ptr[i] > 0) { marked_for_hosp_ptr[i] = 1; }
+                                if (marked_for_ICU_i) { marked_for_ICU_ptr[i] = 1; }
+                                if (marked_for_vent_i) { marked_for_vent_ptr[i] = 1; }
                             }
                         }
-                        else if (!isHospitalized(i,ptd)) {
+                        else if (!inHospital(i,ptd)) {
                             if (counter_ptr[i] >= (latent_period_ptr[i] + infectious_period_ptr[i])) {
                                 status_ptr[i] = Status::immune;
                                 counter_ptr[i] = amrex::RandomNormal(immune_length_mean, immune_length_std, engine);
@@ -216,8 +216,8 @@ void DiseaseStatus<AC,ACT,ACTD,A>::updateAgents(AC& a_agents, /*!< Agent contain
 
             ParallelFor( np, [=] AMREX_GPU_DEVICE (int i) noexcept
             {
-                if (flag_hosp_ptr[i] == 1) {
-                    AMREX_ALWAYS_ASSERT(!isHospitalized(i, ptd));
+                if (marked_for_hosp_ptr[i] == 1) {
+                    AMREX_ALWAYS_ASSERT(!inHospital(i, ptd));
                     assign_hospital( i, hosp_i_ptr, hosp_j_ptr, ptd);
                 }
             });
@@ -226,21 +226,21 @@ void DiseaseStatus<AC,ACT,ACTD,A>::updateAgents(AC& a_agents, /*!< Agent contain
                 auto ds_arr = (*a_stats[d])[mfi].array();
                 ParallelFor( np, [=] AMREX_GPU_DEVICE (int i) noexcept
                 {
-                    if (flag_hosp_ptr[i] == 1) {
+                    if (marked_for_hosp_ptr[i] == 1) {
                         Gpu::Atomic::AddNoRet( &ds_arr(  home_i_ptr[i],
                                                          home_j_ptr[i],
                                                          0,
                                                          DiseaseStats::hospitalization ),
                                                1.0_rt );
                     }
-                    if (flag_ICU_ptr[i] == 1) {
+                    if (marked_for_ICU_ptr[i] == 1) {
                         Gpu::Atomic::AddNoRet( &ds_arr(  home_i_ptr[i],
                                                          home_j_ptr[i],
                                                          0,
                                                          DiseaseStats::ICU ),
                                                1.0_rt );
                     }
-                    if (flag_vent_ptr[i] == 1) {
+                    if (marked_for_vent_ptr[i] == 1) {
                         Gpu::Atomic::AddNoRet( &ds_arr(  home_i_ptr[i],
                                                          home_j_ptr[i],
                                                          0,

--- a/src/DiseaseStatus.H
+++ b/src/DiseaseStatus.H
@@ -175,7 +175,7 @@ void DiseaseStatus<AC,ACT,ACTD,A>::updateAgents(AC& a_agents, /*!< Agent contain
                                 symptomatic_ptr[i] = SymptomStatus::presymptomatic;
                             }
                         }
-                        if (counter_ptr[i] == Math::floor(incubation_period_ptr[i])) {
+                        else if (counter_ptr[i] == Math::floor(incubation_period_ptr[i])) {
                             if (symptomatic_ptr[i] != SymptomStatus::asymptomatic) {
                                 symptomatic_ptr[i] = SymptomStatus::symptomatic;
                             }
@@ -200,7 +200,7 @@ void DiseaseStatus<AC,ACT,ACTD,A>::updateAgents(AC& a_agents, /*!< Agent contain
                                 if (flag_vent_i) { flag_vent_ptr[i] = 1; }
                             }
                         }
-                        if (!isHospitalized(i,ptd)) {
+                        else if (!isHospitalized(i,ptd)) {
                             if (counter_ptr[i] >= (latent_period_ptr[i] + infectious_period_ptr[i])) {
                                 status_ptr[i] = Status::immune;
                                 counter_ptr[i] = amrex::RandomNormal(immune_length_mean, immune_length_std, engine);

--- a/src/HospitalModel.H
+++ b/src/HospitalModel.H
@@ -85,13 +85,13 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents(PCType& a_agents, /*!< A
             int r_RT = RealIdx::nattribs;
 
             GpuArray<int*,ExaEpi::max_num_diseases> status_ptrs, symptomatic_ptrs;
-            GpuArray<ParticleReal*,ExaEpi::max_num_diseases> counter_ptrs, timer_ptrs, latent_per_ptrs;
+            GpuArray<ParticleReal*,ExaEpi::max_num_diseases> counter_ptrs, timer_ptrs, incubation_per_ptrs;
             for (int d = 0; d < n_disease; d++) {
                 status_ptrs[d] = soa.GetIntData(i_RT+i0(d)+IntIdxDisease::status).data();
                 symptomatic_ptrs[d] = soa.GetIntData(i_RT+i0(d)+IntIdxDisease::symptomatic).data();
                 counter_ptrs[d] = soa.GetRealData(r_RT+r0(d)+RealIdxDisease::disease_counter).data();
                 timer_ptrs[d] = soa.GetRealData(r_RT+r0(d)+RealIdxDisease::treatment_timer).data();
-                latent_per_ptrs[d] = soa.GetRealData(r_RT+r0(d)+RealIdxDisease::latent_period).data();
+                incubation_per_ptrs[d] = soa.GetRealData(r_RT+r0(d)+RealIdxDisease::incubation_period).data();
             }
 
             Gpu::DeviceVector<int> is_alive;
@@ -136,7 +136,7 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents(PCType& a_agents, /*!< A
                         // agent is not in hospital
                         return;
                     }
-                    if (counter_ptrs[d][i] == Math::ceil(latent_per_ptrs[d][i])) {
+                    if (counter_ptrs[d][i] == Math::floor(incubation_per_ptrs[d][i])) {
                         // agent just started treatment
                         return;
                     }

--- a/src/HospitalModel.H
+++ b/src/HospitalModel.H
@@ -132,7 +132,7 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents(PCType& a_agents, /*!< A
                                 [=] AMREX_GPU_DEVICE (int i, RandomEngine const& engine)
                                 noexcept
                 {
-                    if ( !isHospitalized(i, ptd) )  {
+                    if ( !inHospital(i, ptd) )  {
                         // agent is not in hospital
                         return;
                     }
@@ -213,7 +213,7 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents(PCType& a_agents, /*!< A
 
             ParallelFor( np, [=] AMREX_GPU_DEVICE (int i) noexcept
             {
-                if ( !isHospitalized(i, ptd) )  { return; }
+                if ( !inHospital(i, ptd) )  { return; }
 
                 if (is_alive_ptr[i] == 0) {
 

--- a/src/InteractionModHome.H
+++ b/src/InteractionModHome.H
@@ -59,7 +59,7 @@ template <typename PTDType>
 struct HomeCandidate {
     AMREX_GPU_HOST_DEVICE
     bool operator() (const int idx, const PTDType& ptd) const noexcept {
-        return !isHospitalized(idx, ptd) && ptd.m_idata[IntIdx::random_travel][idx] < 0 && ptd.m_idata[IntIdx::air_travel][idx] < 0;
+        return !inHospital(idx, ptd) && ptd.m_idata[IntIdx::random_travel][idx] < 0 && ptd.m_idata[IntIdx::air_travel][idx] < 0;
     }
 };
 

--- a/src/InteractionModHomeNborhood.H
+++ b/src/InteractionModHomeNborhood.H
@@ -47,7 +47,7 @@ struct HomeNborhoodCandidate {
     AMREX_GPU_HOST_DEVICE
     bool operator() (const int idx, const PTDType& ptd) const noexcept {
         // this is the only case where we allow random travelers to interact
-        return !isHospitalized(idx, ptd) && !ptd.m_idata[IntIdx::withdrawn][idx];
+        return !inHospital(idx, ptd) && !ptd.m_idata[IntIdx::withdrawn][idx];
     }
 };
 

--- a/src/InteractionModSchool.H
+++ b/src/InteractionModSchool.H
@@ -69,7 +69,7 @@ template <typename PTDType>
 struct SchoolCandidate {
     AMREX_GPU_HOST_DEVICE
     bool operator() (const int idx, const PTDType& ptd) const noexcept {
-        return !isHospitalized(idx, ptd) &&
+        return !inHospital(idx, ptd) &&
                 ptd.m_idata[IntIdx::school][idx] > 0 &&
                 !ptd.m_idata[IntIdx::withdrawn][idx] &&
                 ptd.m_idata[IntIdx::air_travel][idx] < 0 &&

--- a/src/InteractionModWork.H
+++ b/src/InteractionModWork.H
@@ -57,7 +57,7 @@ template <typename PTDType>
 struct WorkCandidate {
     AMREX_GPU_HOST_DEVICE
     bool operator() (const int idx, const PTDType& ptd) const noexcept {
-        return !isHospitalized(idx, ptd) &&
+        return !inHospital(idx, ptd) &&
                 ptd.m_idata[IntIdx::work_i][idx] >= 0 &&
                 ptd.m_idata[IntIdx::workgroup][idx] > 0 &&
                 !ptd.m_idata[IntIdx::withdrawn][idx] &&

--- a/src/InteractionModWorkNborhood.H
+++ b/src/InteractionModWorkNborhood.H
@@ -52,7 +52,7 @@ template <typename PTDType>
 struct WorkNborhoodCandidate {
     AMREX_GPU_HOST_DEVICE
     bool operator() (const int idx, const PTDType& ptd) const noexcept {
-        return !isHospitalized(idx, ptd) && !ptd.m_idata[IntIdx::withdrawn][idx] && ptd.m_idata[IntIdx::random_travel][idx] < 0;
+        return !inHospital(idx, ptd) && !ptd.m_idata[IntIdx::withdrawn][idx] && ptd.m_idata[IntIdx::random_travel][idx] < 0;
     }
 };
 


### PR DESCRIPTION
Fixed situations where an agent can get marked for hospitalization and also get marked as immune if the following condition occurs:
```
Math::floor(incubation_period_ptr[i]) >= (latent_period_ptr[i] + infectious_period_ptr[i]
```
by replacing `if` by `else if` to ensure the agent enters only one of the if-conditions on a given day.

Also, renamed `isHospitalized()` to `inHospital()` to make it clear that this function tests for agent's hospital location (`hosp_i`, `hosp_j`).

Renamed `flag_hosp/ICU/vent` to `marked_for_hosp/ICU/vent` to make it clear that a non-zero value means agent is marked for hosp/ICU/vent but not yet in it.