### PR TITLE
Make the agent redistribution stable if agent.fast = false.

### DIFF
--- a/src/Utils.H
+++ b/src/Utils.H
@@ -84,7 +84,7 @@ struct TestParams
     int nborhood_size = 500;
     int workgroup_size = 20;
 
-    bool fast = true;       /*!< Use the fast implementations for various operations, e.g. binning, at the cost of
+    bool fast = false;       /*!< Use the fast implementations for various operations, e.g. binning, at the cost of
                                  exact reproducibility for a given random seed. */
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -189,6 +189,8 @@ void runAgent ()
     mask_behavior.setVal(1);
 
     AgentContainer pc(geom, dm, ba, params.num_diseases, params.disease_names, params.fast);
+    bool stable_redistribute = !params.fast;
+    pc.setStableRedistribute(stable_redistribute);
     if (params.air_travel_int > 0) pc.setAirTravel(censusData.unit_mf, air, censusData.demo);
 
     {


### PR DESCRIPTION
This also changes the default value of `agent.fast` to `false`. Using the `inputs_random_ca` file, I now get identical `output.dat` files between consecutive runs with the same random seed. 

On my workstation GPU, the time goes up by about 7 seconds on a 4 minute simulation using this option. 