### PR TITLE
Convert to Gamma distributions for the immune, latent, infectious, and incubation lengths.

### DIFF
--- a/docs/source/usage/how_to_run.rst
+++ b/docs/source/usage/how_to_run.rst
@@ -142,22 +142,32 @@ The following inputs specify the disease parameters:
 * ``disease.vac_eff`` (`float`, default ``0``)
     The vaccine efficacy - the probability of transmission will be multiplied by one minus this factor.
     `Vaccination is not yet implemented, so this factor must be left at 0`.
-* ``disease.immune_length_mean`` (`float`, default ``180``)
-    The mean amount of time *in days* agents are immune post-infection
-* ``disease.immune_length_std`` (`float`, default ``60``)
-    The standard deviation associated with the above mean, i.e. the length is drawn from a normal distribution, in days.
-* ``disease.latent_length_mean`` (`float`, default ``3.0``)
-    Mean length of time from exposure until agent becomes infectious, in days.
-* ``disease.latent_length_std`` (`float`, default ``1.0``)
-    Standard deviation of the latent period, in days.
-* ``disease.infectious_length_mean`` (`float`, default ``6.0``)
-    Mean length of the infectious period in days. This counter starts once the latent phase is over.
-* ``disease.infectious_length_std`` (`float`, default ``1.0``)
-    Standard deviation of the infectious period, in days.
-* ``disease.incubation_length_mean`` (`float`, default ``5.0``)
-    Mean length of the time from exposure until symptoms develop, in days.
-* ``disease.incubation_length_std`` (`float`, default ``1.0``)
-    Standard deviation of the time until symptom development, in days.
+* ``disease.immune_length_alpha`` (`float`, default ``9.0``)
+    Alpha parameter for the immunity length Gamma distribution. The immunity length is the length of time in days that agents
+    are immune to the disease after recovering from it. For a Gamma distribution, the mean is alpha*beta and the variance is alpha*beta^2.
+* ``disease.immune_length_beta`` (`float`, default ``20.0``)
+    Beta parameter for the immunity length Gamma distribution. The immunity length is the length of time in days that agents
+    are immune to the disease after recovering from it. For a Gamma distribution, the mean is alpha*beta and the variance is alpha*beta^2.
+* ``disease.latent_length_alpha`` (`float`, default ``9.0``)
+    Alpha parameter for the latent length Gamma distribution. The latent length is the length of time in days until agents become infectious after exposure.
+    For a Gamma distribution, the mean is alpha*beta and the variance is alpha*beta^2.
+* ``disease.latent_length_beta`` (`float`, default ``0.33``)
+    Beta parameter for the latent length Gamma distribution. The latent length is the length of time in days until agents become infectious after exposure.
+    For a Gamma distribution, the mean is alpha*beta and the variance is alpha*beta^2.
+* ``disease.infectious_length_alpha`` (`float`, default ``36.0``)
+    Alpha parameter for the infectious length Gamma distribution. The infectious length is the length of time in days that agents are infectious.
+    This counter starts once the latent phase is over.
+    For a Gamma distribution, the mean is alpha*beta and the variance is alpha*beta^2.
+* ``disease.infectious_length_beta`` (`float`, default ``0.17``)
+    Beta parameter for the infectious length Gamma distribution. The infectious length is the length of time in days that agents are infectious.
+    This counter starts once the latent phase is over.
+    For a Gamma distribution, the mean is alpha*beta and the variance is alpha*beta^2.
+* ``disease.incubation_length_alpha`` (`float`, default ``25.0``)
+    Alpha parameter for the incubation length Gamma distribution. The incubation length is the length of time in days after exposure until agents develop symptoms.
+    For a Gamma distribution, the mean is alpha*beta and the variance is alpha*beta^2.
+* ``disease.incubation_length_beta`` (`float`, default ``0.2``)
+    Beta parameter for the incubation length Gamma distribution. The incubation length is the length of time in days after exposure until agents develop symptoms.
+    For a Gamma distribution, the mean is alpha*beta and the variance is alpha*beta^2.
 * ``disease.hospitalization_days`` (`list of float`, default ``3.0 8.0 7.0``)
     Number of hospitalization days for age groups: under 50, 50-64, 65 and over.
 * ``disease.xmit_comm`` (`list of float`, default ``0.000018125 0.000054375 0.000145 0.000145 0.000145 0.0002175``)

--- a/examples/inputs.ca
+++ b/examples/inputs.ca
@@ -25,5 +25,3 @@ disease.nstrain = 1
 disease.p_trans = 0.20
 disease.p_asymp = 0.40
 disease.reduced_inf = 0.75
-
-#disease.incubation_length_mean = 3.0

--- a/examples/inputs.defaults
+++ b/examples/inputs.defaults
@@ -95,22 +95,22 @@ disease.p_asymp = 0.4
 disease.asymp_relative_inf = 0.75
 # Vaccine efficacy. Not yet implemented; leave at 0.
 disease.vac_eff = 0
-# Mean length in days that agents are immune after recovery from an infection.
-disease.immune_length_mean = 180
-# Standard deviation in days.
-disease.immune_length_std = 60
-# Mean length in days from infection until an agent becomes infectious.
-disease.latent_length_mean = 3.0
-# Standard deviation in days.
-disease.latent_length_std = 1.0
-# Mean length in days for the time an agent is infectious.
-disease.infectious_length_mean = 6.0
-# Standard deviation in days.
-disease.infectious_length_std = 1.0
-# Mean length in days from the time of infectioun untli symptoms develop.
-disease.incubation_length_mean = 5.0
-# Standard deviation in days.
-disease.incubation_length_std = 1.0
+# Alpha parameter for the immume length Gamma distribution. The immune length is the length in days that agents are immune after recovery from an infection.
+disease.immune_length_alpha = 9.0
+# Beta parameter for the immume length Gamma distribution. The immune length is the length in days that agents are immune after recovery from an infection.
+disease.immune_length_beta = 20.0
+# Alpha parameter for the latent length Gamma distribution. The latent length is the length in days from infection until an agent becomes infectious.
+disease.latent_length_alpha = 9.0
+# Beta parameter for the latent length Gamma distribution. The latent length is the length in days from infection until an agent becomes infectious.
+disease.latent_length_beta = 0.33
+# Alpha parameter for the infectious length Gamma distribution. The infectious length is the length in days of the time an agent is infectious.
+disease.infectious_length_alpha = 36.0
+# Beta parameter for the infectious length Gamma distribution. The infectious length is the length in days of the time an agent is infectious.
+disease.infectious_length_beta = 0.17
+# Alpha parameter for the incubation length Gamma distribution. The incubation length is the length in days from the time of infection until symptoms develop.
+disease.incubation_length_alpha = 25.0
+# Beta parameter for the incubation length Gamma distribution. The incubation length is the length in days from the time of infection until symptoms develop.
+disease.incubation_length_beta = 0.2
 
 # Number of days in hospital for the age groups under 50, 50 to 64 and over 64.
 disease.hospitalization_days = 3 8 7

--- a/examples/inputs.ma
+++ b/examples/inputs.ma
@@ -13,8 +13,6 @@ agent.aggregated_diag_prefix = "cases"
 #agent.shelter_start = 7
 #agent.shelter_length = 30
 #agent.shelter_compliance = 0.85
-#agent.immune_length_mean = 180
-#agent.immune_length_std = 60
 
 contact.pSC  = 0.2
 contact.pCO  = 1.45
@@ -32,4 +30,5 @@ disease.p_trans = 0.20
 disease.p_asymp = 0.40
 disease.reduced_inf = 0.75
 
-disease.incubation_length_mean = 3.0
+disease.incubation_length_alpha = 9.0
+disease.incubation_length_beta = 0.33

--- a/examples/inputs.nm
+++ b/examples/inputs.nm
@@ -30,6 +30,3 @@ disease.case_filename = "../CaseData/nm-july4.cases"
 
 # disease_flu.num_initial_cases = 100
 # disease_flu.p_trans = 0.3
-# disease_flu.latent_length_mean = 3.0
-# disease_flu.infectious_length_mean = 3.0
-# disease_flu.incubation_length_mean = 3.0

--- a/examples/inputs_random_ca
+++ b/examples/inputs_random_ca
@@ -23,4 +23,5 @@ disease.p_trans = 0.20
 disease.p_asymp = 0.40
 disease.reduced_inf = 0.75
 
-disease.incubation_length_mean = 3.0
+disease.incubation_length_alpha = 9.0
+disease.incubation_length_beta = 0.33

--- a/src/DiseaseParm.H
+++ b/src/DiseaseParm.H
@@ -82,18 +82,17 @@ struct DiseaseParm
     Real child_compliance; /*!< Child compliance with masking ?? */
     Real child_HH_closure; /*!< Multiplier for household contacts during school closure */
 
-    Real immune_length_mean = 30 * 6;  /*! mean immunity time in days*/
-    Real immune_length_std = 30 * 2;  /*! spread in immunity time in days*/
+    Real immune_length_alpha = 9.0;  /*! alpha parameter for gamma distribution*/
+    Real immune_length_beta = 20.0;  /*! beta parameter for gamma distribution*/
 
-    Real latent_length_mean = 3.0;   /*!< mean time (in days) from initial infection until infectious*/
-    Real latent_length_std = 1.0;   /*!< std dev (in days) for the above*/
+    Real latent_length_alpha = 9.0;  /*! alpha parameter for gamma distribution*/
+    Real latent_length_beta = 0.33;  /*! beta parameter for gamma distribution*/
 
-    Real infectious_length_mean = 6.0;   /*!< mean time (in days) agents are infectious, from the end of the latent period */
-    Real infectious_length_std = 1.0;   /*!< std dev (in days) for the above */
+    Real infectious_length_alpha = 36.0;  /*! alpha parameter for gamma distribution*/
+    Real infectious_length_beta = 0.17;   /*! beta parameter for gamma distribution*/
 
-    Real incubation_length_mean = 5.0;   /*!< mean time (in days) from initial infection until symptoms show */
-    Real incubation_length_std = 1.0;   /*!< std dev (in days) for the above */
-
+    Real incubation_length_alpha = 25.0;  /*! alpha parameter for gamma distribution*/
+    Real incubation_length_beta = 0.2;    /*! beta parameter for gamma distribution*/
 
     /*! number of hospitalization days by age group (#AgeGroups_Hosp); note that the
      *  age groups here are under 50, 50-64, and over 65, and *not* the age groups
@@ -171,11 +170,11 @@ void setInfected ( int* status,
     *status = Status::infected;
     *counter = ParticleReal(0);
     *latent_period =
-        static_cast<ParticleReal>(amrex::RandomNormal(lparm->latent_length_mean, lparm->latent_length_std, engine));
+        static_cast<ParticleReal>(amrex::RandomGamma(lparm->latent_length_alpha, lparm->latent_length_beta, engine));
     *infectious_period =
-        static_cast<ParticleReal>(amrex::RandomNormal(lparm->infectious_length_mean, lparm->infectious_length_std, engine));
+        static_cast<ParticleReal>(amrex::RandomGamma(lparm->infectious_length_alpha, lparm->infectious_length_beta, engine));
     *incubation_period =
-        static_cast<ParticleReal>(amrex::RandomNormal(lparm->incubation_length_mean, lparm->incubation_length_std, engine));
+        static_cast<ParticleReal>(amrex::RandomGamma(lparm->incubation_length_alpha, lparm->incubation_length_beta, engine));
     if (*latent_period < 0) { *latent_period = amrex::Real(0);}
     if (*infectious_period < 0) { *infectious_period = amrex::Real(0);}
     if (*incubation_period < 0) { *incubation_period = amrex::Real(0);}

--- a/src/DiseaseParm.H
+++ b/src/DiseaseParm.H
@@ -82,17 +82,17 @@ struct DiseaseParm
     Real child_compliance; /*!< Child compliance with masking ?? */
     Real child_HH_closure; /*!< Multiplier for household contacts during school closure */
 
-    Real immune_length_alpha = 9.0;  /*! alpha parameter for gamma distribution*/
-    Real immune_length_beta = 20.0;  /*! beta parameter for gamma distribution*/
+    Real immune_length_alpha = Real(9.0);  /*! alpha parameter for gamma distribution*/
+    Real immune_length_beta = Real(20.0);  /*! beta parameter for gamma distribution*/
 
-    Real latent_length_alpha = 9.0;  /*! alpha parameter for gamma distribution*/
-    Real latent_length_beta = 0.33;  /*! beta parameter for gamma distribution*/
+    Real latent_length_alpha = Real(9.0);  /*! alpha parameter for gamma distribution*/
+    Real latent_length_beta = Real(0.33);  /*! beta parameter for gamma distribution*/
 
-    Real infectious_length_alpha = 36.0;  /*! alpha parameter for gamma distribution*/
-    Real infectious_length_beta = 0.17;   /*! beta parameter for gamma distribution*/
+    Real infectious_length_alpha = Real(36.0);  /*! alpha parameter for gamma distribution*/
+    Real infectious_length_beta = Real(0.17);   /*! beta parameter for gamma distribution*/
 
-    Real incubation_length_alpha = 25.0;  /*! alpha parameter for gamma distribution*/
-    Real incubation_length_beta = 0.2;    /*! beta parameter for gamma distribution*/
+    Real incubation_length_alpha = Real(25.0);  /*! alpha parameter for gamma distribution*/
+    Real incubation_length_beta = Real(0.2);    /*! beta parameter for gamma distribution*/
 
     /*! number of hospitalization days by age group (#AgeGroups_Hosp); note that the
      *  age groups here are under 50, 50-64, and over 65, and *not* the age groups

--- a/src/DiseaseParm.cpp
+++ b/src/DiseaseParm.cpp
@@ -74,16 +74,16 @@ void DiseaseParm::readInputs ( const std::string& a_pp_str /*!< Parmparse string
     pp.query("child_compliance", child_compliance);
     pp.query("child_hh_closure", child_HH_closure);
 
-    pp.query("latent_length_mean", latent_length_mean);
-    pp.query("infectious_length_mean", infectious_length_mean);
-    pp.query("incubation_length_mean", incubation_length_mean);
+    pp.query("latent_length_alpha", latent_length_alpha);
+    pp.query("infectious_length_alpha", infectious_length_alpha);
+    pp.query("incubation_length_alpha", incubation_length_alpha);
 
-    pp.query("latent_length_std", latent_length_std);
-    pp.query("infectious_length_std", infectious_length_std);
-    pp.query("incubation_length_std", incubation_length_std);
+    pp.query("latent_length_beta", latent_length_beta);
+    pp.query("infectious_length_beta", infectious_length_beta);
+    pp.query("incubation_length_beta", incubation_length_beta);
 
-    pp.query("immune_length_mean", immune_length_mean);
-    pp.query("immune_length_std", immune_length_std);
+    pp.query("immune_length_alpha", immune_length_alpha);
+    pp.query("immune_length_beta", immune_length_beta);
 
     m_t_hosp_offset = 0;
     queryArray(pp, "hospitalization_days", m_t_hosp, AgeGroups_Hosp::total);

--- a/src/DiseaseStatus.H
+++ b/src/DiseaseStatus.H
@@ -134,8 +134,8 @@ void DiseaseStatus<AC,ACT,ACTD,A>::updateAgents(AC& a_agents, /*!< Agent contain
 
                 auto* disease_parm_d = a_agents.getDiseaseParameters_d(d);
                 auto* disease_parm_h = a_agents.getDiseaseParameters_h(d);
-                auto immune_length_mean = disease_parm_h->immune_length_mean;
-                auto immune_length_std = disease_parm_h->immune_length_std;
+                auto immune_length_alpha = disease_parm_h->immune_length_alpha;
+                auto immune_length_beta = disease_parm_h->immune_length_beta;
 
                 ParallelForRNG( np,
                                 [=] AMREX_GPU_DEVICE (int i, RandomEngine const& engine) noexcept
@@ -179,7 +179,7 @@ void DiseaseStatus<AC,ACT,ACTD,A>::updateAgents(AC& a_agents, /*!< Agent contain
                             if (counter_ptr[i] >= (latent_period_ptr[i] + infectious_period_ptr[i])) {
                                 status_ptr[i] = Status::immune;
                                 counter_ptr[i] =
-                                    static_cast<ParticleReal>(RandomNormal(immune_length_mean, immune_length_std, engine));
+                                    static_cast<ParticleReal>(RandomGamma(immune_length_alpha, immune_length_beta, engine));
                                 symptomatic_ptr[i] = SymptomStatus::presymptomatic;
                                 withdrawn_ptr[i] = 0;
                             }

--- a/src/HospitalModel.H
+++ b/src/HospitalModel.H
@@ -122,8 +122,8 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents(PCType& a_agents, /*!< A
             for (int d = 0; d < n_disease; d++) {
 
                 auto* disease_parm_h = a_agents.getDiseaseParameters_h(d);
-                auto immune_length_mean = disease_parm_h->immune_length_mean;
-                auto immune_length_std = disease_parm_h->immune_length_std;
+                auto immune_length_alpha = disease_parm_h->immune_length_alpha;
+                auto immune_length_beta = disease_parm_h->immune_length_beta;
                 auto* disease_parm_d = a_agents.getDiseaseParameters_d(d);
 
                 ParallelForRNG( np,
@@ -170,7 +170,7 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents(PCType& a_agents, /*!< A
                             // If alive, hospitalized patient recovers
                             status_ptrs[d][i] = Status::immune;
                             counter_ptrs[d][i] =
-                                static_cast<ParticleReal>(RandomNormal(immune_length_mean, immune_length_std, engine));
+                                static_cast<ParticleReal>(RandomGamma(immune_length_alpha, immune_length_beta, engine));
                             symptomatic_ptrs[d][i] = SymptomStatus::presymptomatic;
                             withdrawn_ptr[i] = 0;
                             timer_ptrs[d][i] = 0.0_prt;


### PR DESCRIPTION
The Gamma distribution has two parameters, `alpha` and `beta`. The mean is `alpha*beta` and the variance is `alpha*beta^2`. For converting the default values and the values in the inputs files, I maintained the same mean and variance as the existing code.  