### PR TITLE
Expose xmit_work option

### DIFF
--- a/cmake/GitVersion.cmake
+++ b/cmake/GitVersion.cmake
@@ -25,8 +25,15 @@ function(get_version_from_git)
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 
-    set(EXAEPI_VERSION "${GIT_TAG}-g${GIT_COMMIT_SHORT_HASH}")
-    set(EXAEPI_VERSION "${GIT_TAG}-g${GIT_COMMIT_SHORT_HASH}" PARENT_SCOPE)
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} branch --show-current
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_BRANCH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    set(EXAEPI_VERSION "${GIT_TAG}-g${GIT_COMMIT_SHORT_HASH} (${GIT_BRANCH})")
+    set(EXAEPI_VERSION "${GIT_TAG}-g${GIT_COMMIT_SHORT_HASH} (${GIT_BRANCH})" PARENT_SCOPE)
 
     message(STATUS "Building version ${EXAEPI_VERSION}")
     configure_file(${CMAKE_SOURCE_DIR}/src/version.h.in ${CMAKE_SOURCE_DIR}/src/version.h)

--- a/docs/source/usage/how_to_run.rst
+++ b/docs/source/usage/how_to_run.rst
@@ -158,6 +158,8 @@ The following inputs specify the disease parameters:
     For a Gamma distribution, the mean is alpha*beta and the variance is alpha*beta^2.
 * ``disease.hospitalization_days`` (`list of float`, default ``3.0 8.0 7.0``)
     Number of hospitalization days for age groups: under 50, 50-64, 65 and over.
+* ``disease.xmit_work`` (`float`, default ``0.0575``)
+    Transmission probability within a workgroup.
 * ``disease.xmit_comm`` (`list of float`, default ``0.000018125 0.000054375 0.000145 0.000145 0.000145 0.0002175``)
     Transmission probabilities at the community level, for both work and home locations,
     given the age group of the susceptible agent (0-4, 5-17, 18-29, 30-49, 50-64).

--- a/examples/inputs.defaults
+++ b/examples/inputs.defaults
@@ -138,6 +138,8 @@ disease.xmit_school_a2c = 0 0.0315 0.0315 0.0375 0.0435 0.15
 # Transmission probabilites within schools, where transmitter is a child and receiver is an adult,
 # for school levels none, college, high, middle, elementary, daycare. Ignored for none.
 disease.xmit_school_c2a = 0 0.0315 0.0315 0.0375 0.0435 0.15
+# Transmission probability within workgroups
+disease.xmit_wwork = 0.0575
 
 # Probability of hospitalization when disease symptoms first appear, for age groups 0-4, 5-17, 18-29, 30-49, 50-64, 64+
 disease.CHR = 0.0104 0.0104 0.070 0.28 0.28 1.0

--- a/src/DiseaseParm.cpp
+++ b/src/DiseaseParm.cpp
@@ -63,6 +63,8 @@ void DiseaseParm::readInputs ( const std::string& a_pp_str /*!< Parmparse string
     queryArray(pp, "xmit_school_a2c", xmit_school_a2c, SchoolType::total);
     queryArray(pp, "xmit_school_c2a", xmit_school_c2a, SchoolType::total);
 
+    pp.query("xmit_work", xmit_work);
+
     pp.query("p_trans", p_trans);
     pp.query("p_asymp", p_asymp);
     pp.query("asymp_relative_inf", asymp_relative_inf);


### PR DESCRIPTION
xmit_work is now an option that can be set. Docs have been updated.

Also, added the branch name to the version output.