### PR TITLE
Use comms arena by default

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,9 @@ void overrideAmrexDefaults () {
     bool the_arena_is_managed = true;
     pp.queryAdd("the_arena_is_managed", the_arena_is_managed);
 
+    bool use_comms_arena = true;
+    pp.queryAdd("use_comms_arena", use_comms_arena);
+
     amrex::ParmParse pp2("particles");
     // enable for CPUs, disable for GPUs
     bool do_tiling = TilingIfNotGPU();


### PR DESCRIPTION
Since we turn on managed memory by default, we need to be sure to use a separate, non-managed arena for agent communication. Using managed memory with GPU-aware mpi on Perlmutter performs very poorly. 

Without this change:

Gpus   Time (s)
1           104.5
2           117.2
4           109.9

With it:
Gpus   Time (s)
1           92.89
2           54.92
4           30.41

etc. 