### PR TITLE
Fixed component counting in writing plotfiles

### DIFF
--- a/src/AgentContainer.H
+++ b/src/AgentContainer.H
@@ -124,7 +124,7 @@ class AgentContainer : public amrex::ParticleContainer<0, 0, RealIdx::nattribs, 
 
     void shelterStop();
 
-    void generateCellData(amrex::MultiFab& mf) const;
+    void generateCellData(amrex::MultiFab& mf, const int ncomp) const;
 
     std::array<amrex::Long, 9> getTotals(const int);
 

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -719,15 +719,15 @@ void AgentContainer::infectAgents (MFPtrVec& a_disease_stats /*!< Community-wise
     + component 5*d+3: number of agents that are immune (#Status::immune)
     + component 5*d+4: number of agents that are susceptible infected (#Status::susceptible)
 */
-void AgentContainer::generateCellData (MultiFab& mf,     /*!< MultiFab with at least a_ncomp*m_num_diseases components */
-                                       const int a_ncomp /*!< Number of components per disease */ ) const {
+void AgentContainer::generateCellData (MultiFab& mf, /*!< MultiFab with at least a_ncomp*m_num_diseases components */
+                                       const int a_ncomp /*!< Number of components per disease */) const {
     BL_PROFILE("AgentContainer::generateCellData");
 
     const int lev = 0;
 
     AMREX_ASSERT(OK());
     AMREX_ASSERT(numParticlesOutOfRange(*this, 0) == 0);
-    AMREX_ASSERT(a_ncomp == (Status::dead+1));
+    AMREX_ASSERT(a_ncomp == (Status::dead + 1));
 
     const auto& geom = Geom(lev);
     const auto plo = geom.ProbLoArray();

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -719,13 +719,15 @@ void AgentContainer::infectAgents (MFPtrVec& a_disease_stats /*!< Community-wise
     + component 5*d+3: number of agents that are immune (#Status::immune)
     + component 5*d+4: number of agents that are susceptible infected (#Status::susceptible)
 */
-void AgentContainer::generateCellData (MultiFab& mf /*!< MultiFab with at least 5*m_num_diseases components */) const {
+void AgentContainer::generateCellData (MultiFab& mf,     /*!< MultiFab with at least a_ncomp*m_num_diseases components */
+                                       const int a_ncomp /*!< Number of components per disease */ ) const {
     BL_PROFILE("AgentContainer::generateCellData");
 
     const int lev = 0;
 
     AMREX_ASSERT(OK());
     AMREX_ASSERT(numParticlesOutOfRange(*this, 0) == 0);
+    AMREX_ASSERT(a_ncomp == (Status::dead+1));
 
     const auto& geom = Geom(lev);
     const auto plo = geom.ProbLoArray();
@@ -742,8 +744,8 @@ void AgentContainer::generateCellData (MultiFab& mf /*!< MultiFab with at least 
 
                 for (int d = 0; d < n_disease; d++) {
                     int status = ptd.m_runtime_idata[i0(d) + IntIdxDisease::status][i];
-                    Gpu::Atomic::AddNoRet(&count(iv, 5 * d + 0), 1.0_rt);
-                    if (status != Status::dead) { Gpu::Atomic::AddNoRet(&count(iv, 5 * d + status + 1), 1.0_rt); }
+                    Gpu::Atomic::AddNoRet(&count(iv, a_ncomp * d + 0), 1.0_rt);
+                    if (status != Status::dead) { Gpu::Atomic::AddNoRet(&count(iv, a_ncomp * d + status + 1), 1.0_rt); }
                 }
             },
             false);

--- a/src/IO.cpp
+++ b/src/IO.cpp
@@ -96,6 +96,8 @@ void writePlotFile (const AgentContainer& pc,                      /*!< Agent (p
         plt_varnames.push_back("comm");
         if (unit_mf_ptr != nullptr) { plt_varnames.push_back("unit"); }
 
+        AMREX_ASSERT(plt_varnames.size() == output_mf.nComp());
+
 #ifdef AMREX_USE_HDF5
         WriteSingleLevelPlotfileHDF5MultiDset(amrex::Concatenate("plt", step, 5), output_mf, plt_varnames, pc.ParticleGeom(0),
                                               cur_time, step, "ZLIB@3");

--- a/src/IO.cpp
+++ b/src/IO.cpp
@@ -56,13 +56,15 @@ void writePlotFile (const AgentContainer& pc,                      /*!< Agent (p
                     const int step /*!< Current step */) {
     amrex::Print() << "Writing plotfile \n";
 
-    static const Vector<std::string> status_names = {"total", "never_infected", "infected", "immune", "susceptible", "dead"};
+    // make sure status_names are in the same order as the struct Status in AgentDefinitions.H (do not include "dead")
+    static const Vector<std::string> status_names = {"total", "never_infected", "infected", "immune", "susceptible"};
+
     static const int ncomp_d = status_names.size();
-    static const int ncomp = ncomp_d * num_diseases + (unit_mf_ptr != nullptr ? 4 : 3);
+    static const int ncomp = ncomp_d * num_diseases + num_diseases + (unit_mf_ptr != nullptr ? 4 : 3);
 
     MultiFab output_mf(pc.ParticleBoxArray(0), pc.ParticleDistributionMap(0), ncomp, 0);
     output_mf.setVal(0.0);
-    pc.generateCellData(output_mf);
+    pc.generateCellData(output_mf, ncomp_d);
 
     for (int d = 0; d < num_diseases; d++) {
         amrex::Copy(output_mf, *a_disease_stats[d], DiseaseStats::new_cases, ncomp_d * num_diseases + d, 1, 0);
@@ -70,7 +72,7 @@ void writePlotFile (const AgentContainer& pc,                      /*!< Agent (p
 
     amrex::Copy(output_mf, *FIPS_mf_ptr, 0, ncomp_d * num_diseases + num_diseases, 2, 0);
     amrex::Copy(output_mf, *comm_mf_ptr, 0, ncomp_d * num_diseases + num_diseases + 2, 1, 0);
-    if (unit_mf_ptr != nullptr) { amrex::Copy(output_mf, *unit_mf_ptr, 0, ncomp_d * num_diseases + 2, 1, 0); }
+    if (unit_mf_ptr != nullptr) { amrex::Copy(output_mf, *unit_mf_ptr, 0, ncomp_d * num_diseases + 3, 1, 0); }
 
     {
         Vector<std::string> plt_varnames = {};
@@ -225,7 +227,7 @@ void writeFIPSData (const AgentContainer& agents,                  /*!< Agents (
     for (int lev = 0; lev < nlevs; ++lev) {
         mf_vec[lev] = std::make_unique<MultiFab>(agents.ParticleBoxArray(lev), agents.ParticleDistributionMap(lev), ncomp, 0);
         mf_vec[lev]->setVal(0.0);
-        agents.generateCellData(*mf_vec[lev]);
+        agents.generateCellData(*mf_vec[lev], ncomp_d);
     }
 
     for (int d = 0; d < num_diseases; d++) {
@@ -305,7 +307,7 @@ void writeAggregatedData (const AgentContainer& agents,                  /*!< Ag
     for (int lev = 0; lev < nlevs; ++lev) {
         mf_vec[lev] = std::make_unique<MultiFab>(agents.ParticleBoxArray(lev), agents.ParticleDistributionMap(lev), ncomp, 0);
         mf_vec[lev]->setVal(0.0);
-        agents.generateCellData(*mf_vec[lev]);
+        agents.generateCellData(*mf_vec[lev], ncomp_d);
     }
 
     for (int d = 0; d < num_diseases; d++) {


### PR DESCRIPTION
There was a mistake in component counting and offsetting when writing plotfiles; somehow it did not show for single-disease sims but caused code to crash for multi-diseases.

Also added a check in `AgentContainer::generateCellData()`.