### PR TITLE
Allow building with HIP devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ if(NOT ${amrex}_POPULATED)
   if(AMReX_GPU_BACKEND STREQUAL "CUDA")
     enable_language(CUDA)
     # include(AMReX_SetupCUDA)
+  elseif(AMReX_GPU_BACKEND STREQUAL "HIP")
   endif()
 
   # Bring the populated content into the build

--- a/src/InteractionModel.H
+++ b/src/InteractionModel.H
@@ -289,7 +289,7 @@ struct GetCommunityIndex {
 #if defined(AMREX_USE_CUDA)
 #define devMemset cudaMemset
 #elif defined(AMREX_USE_HIP)
-#define devMemset hipMemset
+#define devMemset (void)hipMemset
 #else
 #define devMemset memset
 #endif

--- a/src/InteractionModel.H
+++ b/src/InteractionModel.H
@@ -286,8 +286,10 @@ struct GetCommunityIndex {
     int num_comms;
 };
 
-#ifdef AMREX_USE_CUDA
+#if defined(AMREX_USE_CUDA)
 #define devMemset cudaMemset
+#elif defined(AMREX_USE_HIP)
+#define devMemset hipMemset
 #else
 #define devMemset memset
 #endif

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -51,7 +51,7 @@ void ExaEpi::Utils::getTestParams (TestParams& params, /*!< Test parameters */
     } else if (ic_type == "urbanpop") {
         params.ic_type = ICType::UrbanPop;
         pp.get("urbanpop_filename", params.urbanpop_filename);
-#ifdef AMREX_USE_CUDA
+#if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
         params.max_box_size = 500;
 #else
         params.max_box_size = 100;


### PR DESCRIPTION
This PR allows to build ExaEpi on HIP device enabled platforms.

For example, to build on tuolumne.llnl.gov, that has four AMD MI300A and 4th gen EPYC CPU per compute node, do as follows:

- Load necessary modules including rocm, mpi and c++ compiler: `module load PrgEnv-gnu-amd/8.6.0 rocm/6.3.1hangfix cray-mpich/8.1.32`
- Change directory in to build directory: `mkdir build; cd build`
- Find out the device id: `rocminfo | awk '((NF==2) && ($1=="Name:") && ($2 ~ /^gfx/)) {print $2}' | uniq`
- Set the environment variable for the HIP device id:  `export AMD_ARCH=gfx942`
- Run cmake: ``cmake -DAMReX_GPU_BACKEND=HIP -DAMReX_AMD_ARCH=${AMD_ARCH} -DCMAKE_INSTALL_PREFIX=`realpath ..`/install ..``
- Compile: `make -j 16`

