### PR TITLE
Fixed bug in indexing in call to setInfected in infectRandomCommunity

### DIFF
--- a/src/InitializeInfections.cpp
+++ b/src/InitializeInfections.cpp
@@ -114,7 +114,7 @@ static int infectRandomCommunity (AgentContainer& pc,                      /*!< 
                     }
                 } else {
                     setInfected(&(status_ptr[pindex]), &(counter_ptr[pindex]), &(latent_period_ptr[pindex]),
-                                &(infectious_period_ptr[pindex]), &(incubation_period_ptr[pindex]), &(hospital_delay_ptr[i]),
+                                &(infectious_period_ptr[pindex]), &(incubation_period_ptr[pindex]), &(hospital_delay_ptr[pindex]),
                                 engine, lparm);
                     ++ni;
                 }


### PR DESCRIPTION
This was a bug introduced in e1bc31044523e77abd25edd3f320c9e34b84d351, the change that added the hospitalization delay.