### PR TITLE
Fix data offset for unit_mf plotfile

### DIFF
--- a/src/IO.cpp
+++ b/src/IO.cpp
@@ -72,7 +72,7 @@ void writePlotFile (const AgentContainer& pc,                      /*!< Agent (p
 
     amrex::Copy(output_mf, *FIPS_mf_ptr, 0, ncomp_d * num_diseases + num_diseases, 2, 0);
     amrex::Copy(output_mf, *comm_mf_ptr, 0, ncomp_d * num_diseases + num_diseases + 2, 1, 0);
-    if (unit_mf_ptr != nullptr) { amrex::Copy(output_mf, *unit_mf_ptr, 0, ncomp_d * num_diseases + 3, 1, 0); }
+    if (unit_mf_ptr != nullptr) { amrex::Copy(output_mf, *unit_mf_ptr, 0, ncomp_d * num_diseases + num_diseases + 3, 1, 0); }
 
     {
         Vector<std::string> plt_varnames = {};


### PR DESCRIPTION
Correctly copies unit_mf to the component after the community_mf, fixing data loss (specifically overwriting community number data if ran with one disease).

It's not clear to me that keeping the `new_cases` field uncounted from `ncomp_d` is the clearest/most future-proof design, but until that decision is made we can have this fix.