### PR TITLE
Change format of output.dat to support GSA runs

### DIFF
--- a/src/AgentContainer.H
+++ b/src/AgentContainer.H
@@ -126,7 +126,7 @@ class AgentContainer : public amrex::ParticleContainer<0, 0, RealIdx::nattribs, 
 
     void generateCellData(amrex::MultiFab& mf, const int ncomp) const;
 
-    std::array<amrex::Long, 9> getTotals(const int);
+    std::array<amrex::Long, OutputStatus::nattribs> getTotals(const int);
 
     int getMaxGroup(const int group_idx);
 

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -777,13 +777,9 @@ std::array<Long, OutputStatus::nattribs> AgentContainer::getTotals (const int a_
 
                 if (status == Status::dead) { s[OutputStatus::D] = 1; }
 
-        if (isNewlySymptomatic(i, ptd, a_d)) {
-            s[OutputStatus::NewS] = 1;
-        }
+                if (isNewlySymptomatic(i, ptd, a_d)) { s[OutputStatus::NewS] = 1; }
 
-        if (isNewlyHospitalized(i, ptd, a_d)) {
-            s[OutputStatus::NewH] = 1;
-        }
+                if (isNewlyHospitalized(i, ptd, a_d)) { s[OutputStatus::NewH] = 1; }
 
                 if (!inHospital(i, ptd)) {                           // do not include hospitalized agents in these counts
                     if (status == Status::infected) {                // exposed

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -777,6 +777,10 @@ std::array<Long, OutputStatus::nattribs> AgentContainer::getTotals (const int a_
 
                 if (status == Status::dead) { s[OutputStatus::D] = 1; }
 
+		if (isNewlySymptomatic(i, ptd, a_d)) {
+		    s[OutputStatus::NewS] = 1;
+		}
+
                 if (!inHospital(i, ptd)) {                           // do not include hospitalized agents in these counts
                     if (status == Status::infected) {                // exposed
                         if (notInfectiousButInfected(i, ptd, a_d)) { // exposed, but not infectious

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -777,13 +777,13 @@ std::array<Long, OutputStatus::nattribs> AgentContainer::getTotals (const int a_
 
                 if (status == Status::dead) { s[OutputStatus::D] = 1; }
 
-		if (isNewlySymptomatic(i, ptd, a_d)) {
-		    s[OutputStatus::NewS] = 1;
-		}
+        if (isNewlySymptomatic(i, ptd, a_d)) {
+            s[OutputStatus::NewS] = 1;
+        }
 
-		if (isNewlyHospitalized(i, ptd, a_d)) {
-		    s[OutputStatus::NewH] = 1;
-		}
+        if (isNewlyHospitalized(i, ptd, a_d)) {
+            s[OutputStatus::NewH] = 1;
+        }
 
                 if (!inHospital(i, ptd)) {                           // do not include hospitalized agents in these counts
                     if (status == Status::infected) {                // exposed

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -759,7 +759,7 @@ void AgentContainer::generateCellData (MultiFab& mf, /*!< MultiFab with at least
 std::array<Long, OutputStatus::nattribs> AgentContainer::getTotals (const int a_d /*!< disease index */) {
     BL_PROFILE("getTotals");
     amrex::ReduceOps<ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum,
-                     ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum>
+                     ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum>
             reduce_ops;
     auto r = amrex::ParticleReduce<ReduceData<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>>(
             *this,
@@ -779,6 +779,10 @@ std::array<Long, OutputStatus::nattribs> AgentContainer::getTotals (const int a_
 
 		if (isNewlySymptomatic(i, ptd, a_d)) {
 		    s[OutputStatus::NewS] = 1;
+		}
+
+		if (isNewlyHospitalized(i, ptd, a_d)) {
+		    s[OutputStatus::NewH] = 1;
 		}
 
                 if (!inHospital(i, ptd)) {                           // do not include hospitalized agents in these counts

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -763,28 +763,22 @@ std::array<Long, OutputStatus::nattribs> AgentContainer::getTotals (const int a_
             reduce_ops;
     auto r = amrex::ParticleReduce<ReduceData<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>>(
             *this,
-            [=] AMREX_GPU_DEVICE (const AgentContainer::ParticleTileType::ConstParticleTileDataType& ptd,
-                                  const int i) noexcept -> amrex::GpuTuple<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int> {
+            [=] AMREX_GPU_DEVICE (const AgentContainer::ParticleTileType::ConstParticleTileDataType& ptd, const int i) noexcept
+                    -> amrex::GpuTuple<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int> {
                 int s[15] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
                 auto status = ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::status][i];
 
                 AMREX_ALWAYS_ASSERT(status >= 0);
                 AMREX_ALWAYS_ASSERT(status <= 4);
 
-                if (status == Status::never || status == Status::susceptible) {
-                    s[OutputStatus::Su] = 1;
-                }
+                if (status == Status::never || status == Status::susceptible) { s[OutputStatus::Su] = 1; }
 
-                if (status == Status::immune) {
-                    s[OutputStatus::R] = 1;
-                }
+                if (status == Status::immune) { s[OutputStatus::R] = 1; }
 
-                if (status == Status::dead) {
-                    s[OutputStatus::D] = 1;
-                }
+                if (status == Status::dead) { s[OutputStatus::D] = 1; }
 
-                if (!inHospital(i, ptd)) { // do not include hospitalized agents in these counts
-                    if (status == Status::infected) { // exposed
+                if (!inHospital(i, ptd)) {                           // do not include hospitalized agents in these counts
+                    if (status == Status::infected) {                // exposed
                         if (notInfectiousButInfected(i, ptd, a_d)) { // exposed, but not infectious
                             if (isAsymptomatic(i, ptd, a_d)) {
                                 s[OutputStatus::A_PI] = 1;
@@ -818,9 +812,10 @@ std::array<Long, OutputStatus::nattribs> AgentContainer::getTotals (const int a_
             },
             reduce_ops);
 
-    std::array<Long, OutputStatus::nattribs> counts = {amrex::get<0>(r), amrex::get<1>(r), amrex::get<2>(r), amrex::get<3>(r), amrex::get<4>(r),
-                                                       amrex::get<5>(r), amrex::get<6>(r), amrex::get<7>(r), amrex::get<8>(r), amrex::get<9>(r),
-                                                       amrex::get<10>(r), amrex::get<11>(r), amrex::get<12>(r), amrex::get<13>(r), amrex::get<14>(r)};
+    std::array<Long, OutputStatus::nattribs> counts = {amrex::get<0>(r),  amrex::get<1>(r),  amrex::get<2>(r),  amrex::get<3>(r),
+                                                       amrex::get<4>(r),  amrex::get<5>(r),  amrex::get<6>(r),  amrex::get<7>(r),
+                                                       amrex::get<8>(r),  amrex::get<9>(r),  amrex::get<10>(r), amrex::get<11>(r),
+                                                       amrex::get<12>(r), amrex::get<13>(r), amrex::get<14>(r)};
     ParallelDescriptor::ReduceLongSum(&counts[0], OutputStatus::nattribs, ParallelDescriptor::IOProcessorNumber());
     return counts;
 }

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -751,56 +751,77 @@ void AgentContainer::generateCellData (MultiFab& mf, /*!< MultiFab with at least
             false);
 }
 
-/*! \brief Computes the total number of agents with each #Status
+/*! \brief Computes the total number of agents with each #OutputStatus
 
-    Returns a vector with 5 components corresponding to each value of #Status; each element is
-    the total number of agents at a step with the corresponding #Status (in that order).
-
-    Status list: 0 - never, 1 - infected, 2 - immune, 3 - susceptible, 4 - dead, 5 - exposed, 6 - asymptomatic,
-                 7 - presymptomatic, 8 - symptomatic
+    Returns a vector with 15 components corresponding to each value of #OutputStatus; each element is
+    the total number of agents at a step with the corresponding #OutputStatus (in that order).
 */
-std::array<Long, 9> AgentContainer::getTotals (const int a_d /*!< disease index */) {
+std::array<Long, OutputStatus::nattribs> AgentContainer::getTotals (const int a_d /*!< disease index */) {
     BL_PROFILE("getTotals");
     amrex::ReduceOps<ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum,
-                     ReduceOpSum>
+                     ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum>
             reduce_ops;
-    auto r = amrex::ParticleReduce<ReduceData<int, int, int, int, int, int, int, int, int>>(
+    auto r = amrex::ParticleReduce<ReduceData<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int>>(
             *this,
             [=] AMREX_GPU_DEVICE (const AgentContainer::ParticleTileType::ConstParticleTileDataType& ptd,
-                                 const int i) noexcept -> amrex::GpuTuple<int, int, int, int, int, int, int, int, int> {
-                int s[9] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
+                                  const int i) noexcept -> amrex::GpuTuple<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int> {
+                int s[15] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
                 auto status = ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::status][i];
 
                 AMREX_ALWAYS_ASSERT(status >= 0);
                 AMREX_ALWAYS_ASSERT(status <= 4);
 
-                s[status] = 1;
+                if (status == Status::never || status == Status::susceptible) {
+                    s[OutputStatus::Su] = 1;
+                }
+
+                if (status == Status::immune) {
+                    s[OutputStatus::R] = 1;
+                }
+
+                if (status == Status::dead) {
+                    s[OutputStatus::D] = 1;
+                }
 
                 if (!inHospital(i, ptd)) { // do not include hospitalized agents in these counts
                     if (status == Status::infected) { // exposed
-                        if (notInfectiousButInfected(i, ptd, a_d)) {
-                            s[5] = 1;                 // exposed, but not infectious
-                        } else {                      // infectious
-                            if (ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][i] == SymptomStatus::asymptomatic) {
-                                s[6] = 1;             // asymptomatic and will remain so
-                            } else if (ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][i] ==
-                                       SymptomStatus::presymptomatic) {
-                                s[7] = 1;             // asymptomatic but will develop symptoms
-                            } else if (ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][i] == SymptomStatus::symptomatic) {
-                                s[8] = 1;             // Infectious and symptomatic
+                        if (notInfectiousButInfected(i, ptd, a_d)) { // exposed, but not infectious
+                            if (isAsymptomatic(i, ptd, a_d)) {
+                                s[OutputStatus::A_PI] = 1;
+                            } else if (isPresymptomatic(i, ptd, a_d)) {
+                                s[OutputStatus::PS_PI] = 1;
+                            } else if (isSymptomatic(i, ptd, a_d)) {
+                                s[OutputStatus::S_PI] = 1;
+                            } else {
+                                amrex::Abort("how did I get here?");
+                            }
+                        } else { // currently infectious
+                            if (isAsymptomatic(i, ptd, a_d)) {
+                                s[OutputStatus::A_I] = 1;
+                            } else if (isPresymptomatic(i, ptd, a_d)) {
+                                s[OutputStatus::PS_I] = 1;
+                            } else if (isSymptomatic(i, ptd, a_d)) {
+                                s[OutputStatus::S_I] = 1;
                             } else {
                                 amrex::Abort("how did I get here?");
                             }
                         }
                     }
+                } else { // now the hospitalized categories
+                    if (notInfectiousButInfected(i, ptd, a_d)) {
+                        s[OutputStatus::H_NI] = 1;
+                    } else {
+                        s[OutputStatus::H_I] = 1;
+                    }
                 }
-                return {s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], s[8]};
+                return {s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], s[8], s[9], s[10], s[11], s[12], s[13], s[14]};
             },
             reduce_ops);
 
-    std::array<Long, 9> counts = {amrex::get<0>(r), amrex::get<1>(r), amrex::get<2>(r), amrex::get<3>(r), amrex::get<4>(r),
-                                  amrex::get<5>(r), amrex::get<6>(r), amrex::get<7>(r), amrex::get<8>(r)};
-    ParallelDescriptor::ReduceLongSum(&counts[0], 9, ParallelDescriptor::IOProcessorNumber());
+    std::array<Long, OutputStatus::nattribs> counts = {amrex::get<0>(r), amrex::get<1>(r), amrex::get<2>(r), amrex::get<3>(r), amrex::get<4>(r),
+                                                       amrex::get<5>(r), amrex::get<6>(r), amrex::get<7>(r), amrex::get<8>(r), amrex::get<9>(r),
+                                                       amrex::get<10>(r), amrex::get<11>(r), amrex::get<12>(r), amrex::get<13>(r), amrex::get<14>(r)};
+    ParallelDescriptor::ReduceLongSum(&counts[0], OutputStatus::nattribs, ParallelDescriptor::IOProcessorNumber());
     return counts;
 }
 

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -776,19 +776,21 @@ std::array<Long, 9> AgentContainer::getTotals (const int a_d /*!< disease index 
 
                 s[status] = 1;
 
-                if (status == Status::infected) { // exposed
-                    if (notInfectiousButInfected(i, ptd, a_d)) {
-                        s[5] = 1;                 // exposed, but not infectious
-                    } else {                      // infectious
-                        if (ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][i] == SymptomStatus::asymptomatic) {
-                            s[6] = 1;             // asymptomatic and will remain so
-                        } else if (ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][i] ==
-                                   SymptomStatus::presymptomatic) {
-                            s[7] = 1;             // asymptomatic but will develop symptoms
-                        } else if (ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][i] == SymptomStatus::symptomatic) {
-                            s[8] = 1;             // Infectious and symptomatic
-                        } else {
-                            amrex::Abort("how did I get here?");
+                if (!inHospital(i, ptd)) { // do not include hospitalized agents in these counts
+                    if (status == Status::infected) { // exposed
+                        if (notInfectiousButInfected(i, ptd, a_d)) {
+                            s[5] = 1;                 // exposed, but not infectious
+                        } else {                      // infectious
+                            if (ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][i] == SymptomStatus::asymptomatic) {
+                                s[6] = 1;             // asymptomatic and will remain so
+                            } else if (ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][i] ==
+                                       SymptomStatus::presymptomatic) {
+                                s[7] = 1;             // asymptomatic but will develop symptoms
+                            } else if (ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][i] == SymptomStatus::symptomatic) {
+                                s[8] = 1;             // Infectious and symptomatic
+                            } else {
+                                amrex::Abort("how did I get here?");
+                            }
                         }
                     }
                 }

--- a/src/AgentDefinitions.H
+++ b/src/AgentDefinitions.H
@@ -281,6 +281,25 @@ bool inHospital (const int a_idx, /*!< Agent index */
     return ((a_ptd.m_idata[IntIdx::hosp_i][a_idx] >= 0) && (a_ptd.m_idata[IntIdx::hosp_j][a_idx] >= 0));
 }
 
+/*! \brief Did the agent just become hospitalized this step? */
+template <typename PTDType>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+bool isNewlyHospitalized (const int a_idx,      /*!< Agent index */
+                    const PTDType& a_ptd, /*!< Particle tile data */
+                    const int a_d /*!< Disease index */) {
+    int delay = amrex::Math::floor(a_ptd.rdata(r0(a_d) + RealIdxDisease::hospital_delay)[a_idx]);
+    int incub = amrex::Math::floor(a_ptd.rdata(r0(a_d) + RealIdxDisease::incubation_period)[a_idx]);
+    if (isNewlySymptomatic(a_idx, a_ptd, a_d) && (delay == 0) && inHospital(a_idx, a_ptd)) {
+        return true;
+    } else if ((a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::status][a_idx] == Status::infected) &&
+               (a_ptd.rdata(r0(a_d) + RealIdxDisease::disease_counter)[a_idx] == incub + delay) &&
+               inHospital(a_idx, a_ptd)) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 /*! \brief Is agent an adult? */
 template <typename PTDType>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE

--- a/src/AgentDefinitions.H
+++ b/src/AgentDefinitions.H
@@ -162,6 +162,62 @@ struct SymptomStatus {
     };
 };
 
+struct OutputStatus {
+    enum {
+        /* Total number of agents in each category are written to summary table each step */
+        Su = 0, /*!< Susceptible */
+        PS_PI,  /*!< Presymptomatic/Preinfectious */
+        S_PI,   /*!< Symptomatic/Preinfectious */
+        PS_I,   /*!< Presymptomatic/Infectious */
+        S_I,    /*!< Symptomatic/Infectious */
+        A_PI,   /*!< Asymptomatic/Preinfectious */
+        A_I,    /*!< Asymptomatic/Infectious */
+        H_NI,   /*!< Hospitalized/Noninfectious */
+        H_I,    /*!< Hostitalized/Infectious */
+        ICU,    /*!< In the ICU */
+        V,      /*!< On ventilator */
+	R,      /*!< Recovered */
+        D,      /*!< Dead */
+        NewS,   /*!< Became symptomatic this step */
+        NewH,   /*!< Became hospitalized this step */
+        nattribs
+    };
+};
+
+/*! \brief Get the total number of exposed agents (in or out of hospital) */
+AMREX_FORCE_INLINE
+amrex::Long totalExposed (const std::array<amrex::Long, OutputStatus::nattribs> counts) {
+    return counts[OutputStatus::PS_PI] + counts[OutputStatus::S_PI] + counts[OutputStatus::S_I] + counts[OutputStatus::PS_I] +
+	counts[OutputStatus::A_PI] + counts[OutputStatus::A_I] + counts[OutputStatus::H_NI] + counts[OutputStatus::H_I];
+}
+
+/*! \brief Is an agent symptomatic? */
+template <typename PTDType>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+bool isSymptomatic (const int a_idx,      /*!< Agent index */
+                    const PTDType& a_ptd, /*!< Particle tile data */
+                    const int a_d /*!< Disease index */) {
+    return a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][a_idx] == SymptomStatus::symptomatic;
+}
+
+/*! \brief Is an agent asymptomatic (does not currently have symptoms and will not develop them)? */
+template <typename PTDType>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+bool isAsymptomatic (const int a_idx,      /*!< Agent index */
+		     const PTDType& a_ptd, /*!< Particle tile data */
+		     const int a_d /*!< Disease index */) {
+    return a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][a_idx] == SymptomStatus::asymptomatic;
+}
+
+/*! \brief Is an agent presymptomatic (does not currently have symptoms but will develop them)? */
+template <typename PTDType>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+bool isPresymptomatic (const int a_idx,      /*!< Agent index */
+		     const PTDType& a_ptd, /*!< Particle tile data */
+		     const int a_d /*!< Disease index */) {
+    return a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][a_idx] == SymptomStatus::presymptomatic;
+}
+
 /*! \brief Is an agent infected but not infectious? */
 template <typename PTDType>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE

--- a/src/AgentDefinitions.H
+++ b/src/AgentDefinitions.H
@@ -204,11 +204,12 @@ bool isSymptomatic (const int a_idx,      /*!< Agent index */
 template <typename PTDType>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 bool isNewlySymptomatic (const int a_idx,      /*!< Agent index */
-                    const PTDType& a_ptd, /*!< Particle tile data */
-                    const int a_d /*!< Disease index */) {
+                         const PTDType& a_ptd, /*!< Particle tile data */
+                         const int a_d /*!< Disease index */) {
     return (a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::status][a_idx] == Status::infected) &&
-    (a_ptd.m_runtime_rdata[r0(a_d) + RealIdxDisease::disease_counter][a_idx] == amrex::Math::floor(a_ptd.m_runtime_rdata[r0(a_d) + RealIdxDisease::incubation_period][a_idx])) &&
-    (a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][a_idx] == SymptomStatus::symptomatic);
+           (a_ptd.m_runtime_rdata[r0(a_d) + RealIdxDisease::disease_counter][a_idx] ==
+            amrex::Math::floor(a_ptd.m_runtime_rdata[r0(a_d) + RealIdxDisease::incubation_period][a_idx])) &&
+           (a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][a_idx] == SymptomStatus::symptomatic);
 }
 
 /*! \brief Is an agent asymptomatic (does not currently have symptoms and will not develop them)? */
@@ -285,8 +286,8 @@ bool inHospital (const int a_idx, /*!< Agent index */
 template <typename PTDType>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 bool isNewlyHospitalized (const int a_idx,      /*!< Agent index */
-                    const PTDType& a_ptd, /*!< Particle tile data */
-                    const int a_d /*!< Disease index */) {
+                          const PTDType& a_ptd, /*!< Particle tile data */
+                          const int a_d /*!< Disease index */) {
     amrex::Real delay = amrex::Math::floor(a_ptd.m_runtime_rdata[r0(a_d) + RealIdxDisease::hospital_delay][a_idx]);
     amrex::Real incub = amrex::Math::floor(a_ptd.m_runtime_rdata[r0(a_d) + RealIdxDisease::incubation_period][a_idx]);
     if (isNewlySymptomatic(a_idx, a_ptd, a_d) && (delay == 0) && inHospital(a_idx, a_ptd)) {

--- a/src/AgentDefinitions.H
+++ b/src/AgentDefinitions.H
@@ -207,7 +207,7 @@ bool isNewlySymptomatic (const int a_idx,      /*!< Agent index */
                     const PTDType& a_ptd, /*!< Particle tile data */
                     const int a_d /*!< Disease index */) {
     return (a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::status][a_idx] == Status::infected) &&
-    (a_ptd.rdata(r0(a_d) + RealIdxDisease::disease_counter)[a_idx] == amrex::Math::floor(a_ptd.rdata(r0(a_d) + RealIdxDisease::incubation_period)[a_idx])) &&
+    (a_ptd.m_runtime_rdata[r0(a_d) + RealIdxDisease::disease_counter][a_idx] == amrex::Math::floor(a_ptd.m_runtime_rdata[r0(a_d) + RealIdxDisease::incubation_period][a_idx])) &&
     (a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][a_idx] == SymptomStatus::symptomatic);
 }
 
@@ -287,12 +287,12 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 bool isNewlyHospitalized (const int a_idx,      /*!< Agent index */
                     const PTDType& a_ptd, /*!< Particle tile data */
                     const int a_d /*!< Disease index */) {
-    amrex::Real delay = amrex::Math::floor(a_ptd.rdata(r0(a_d) + RealIdxDisease::hospital_delay)[a_idx]);
-    amrex::Real incub = amrex::Math::floor(a_ptd.rdata(r0(a_d) + RealIdxDisease::incubation_period)[a_idx]);
+    amrex::Real delay = amrex::Math::floor(a_ptd.m_runtime_rdata[r0(a_d) + RealIdxDisease::hospital_delay][a_idx]);
+    amrex::Real incub = amrex::Math::floor(a_ptd.m_runtime_rdata[r0(a_d) + RealIdxDisease::incubation_period][a_idx]);
     if (isNewlySymptomatic(a_idx, a_ptd, a_d) && (delay == 0) && inHospital(a_idx, a_ptd)) {
         return true;
     } else if ((a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::status][a_idx] == Status::infected) &&
-               (a_ptd.rdata(r0(a_d) + RealIdxDisease::disease_counter)[a_idx] == incub + delay) &&
+               (a_ptd.m_runtime_rdata[r0(a_d) + RealIdxDisease::disease_counter][a_idx] == incub + delay) &&
                inHospital(a_idx, a_ptd)) {
         return true;
     } else {

--- a/src/AgentDefinitions.H
+++ b/src/AgentDefinitions.H
@@ -176,7 +176,7 @@ struct OutputStatus {
         H_I,    /*!< Hostitalized/Infectious */
         ICU,    /*!< In the ICU */
         V,      /*!< On ventilator */
-    R,      /*!< Recovered */
+        R,      /*!< Recovered */
         D,      /*!< Dead */
         NewS,   /*!< Became symptomatic this step */
         NewH,   /*!< Became hospitalized this step */
@@ -188,7 +188,7 @@ struct OutputStatus {
 AMREX_FORCE_INLINE
 amrex::Long totalExposed (const std::array<amrex::Long, OutputStatus::nattribs> counts) {
     return counts[OutputStatus::PS_PI] + counts[OutputStatus::S_PI] + counts[OutputStatus::S_I] + counts[OutputStatus::PS_I] +
-    counts[OutputStatus::A_PI] + counts[OutputStatus::A_I] + counts[OutputStatus::H_NI] + counts[OutputStatus::H_I];
+           counts[OutputStatus::A_PI] + counts[OutputStatus::A_I] + counts[OutputStatus::H_NI] + counts[OutputStatus::H_I];
 }
 
 /*! \brief Is an agent symptomatic? */
@@ -204,8 +204,8 @@ bool isSymptomatic (const int a_idx,      /*!< Agent index */
 template <typename PTDType>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 bool isAsymptomatic (const int a_idx,      /*!< Agent index */
-             const PTDType& a_ptd, /*!< Particle tile data */
-             const int a_d /*!< Disease index */) {
+                     const PTDType& a_ptd, /*!< Particle tile data */
+                     const int a_d /*!< Disease index */) {
     return a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][a_idx] == SymptomStatus::asymptomatic;
 }
 
@@ -213,8 +213,8 @@ bool isAsymptomatic (const int a_idx,      /*!< Agent index */
 template <typename PTDType>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 bool isPresymptomatic (const int a_idx,      /*!< Agent index */
-             const PTDType& a_ptd, /*!< Particle tile data */
-             const int a_d /*!< Disease index */) {
+                       const PTDType& a_ptd, /*!< Particle tile data */
+                       const int a_d /*!< Disease index */) {
     return a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][a_idx] == SymptomStatus::presymptomatic;
 }
 

--- a/src/AgentDefinitions.H
+++ b/src/AgentDefinitions.H
@@ -176,7 +176,7 @@ struct OutputStatus {
         H_I,    /*!< Hostitalized/Infectious */
         ICU,    /*!< In the ICU */
         V,      /*!< On ventilator */
-	R,      /*!< Recovered */
+    R,      /*!< Recovered */
         D,      /*!< Dead */
         NewS,   /*!< Became symptomatic this step */
         NewH,   /*!< Became hospitalized this step */
@@ -188,7 +188,7 @@ struct OutputStatus {
 AMREX_FORCE_INLINE
 amrex::Long totalExposed (const std::array<amrex::Long, OutputStatus::nattribs> counts) {
     return counts[OutputStatus::PS_PI] + counts[OutputStatus::S_PI] + counts[OutputStatus::S_I] + counts[OutputStatus::PS_I] +
-	counts[OutputStatus::A_PI] + counts[OutputStatus::A_I] + counts[OutputStatus::H_NI] + counts[OutputStatus::H_I];
+    counts[OutputStatus::A_PI] + counts[OutputStatus::A_I] + counts[OutputStatus::H_NI] + counts[OutputStatus::H_I];
 }
 
 /*! \brief Is an agent symptomatic? */
@@ -204,8 +204,8 @@ bool isSymptomatic (const int a_idx,      /*!< Agent index */
 template <typename PTDType>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 bool isAsymptomatic (const int a_idx,      /*!< Agent index */
-		     const PTDType& a_ptd, /*!< Particle tile data */
-		     const int a_d /*!< Disease index */) {
+             const PTDType& a_ptd, /*!< Particle tile data */
+             const int a_d /*!< Disease index */) {
     return a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][a_idx] == SymptomStatus::asymptomatic;
 }
 
@@ -213,8 +213,8 @@ bool isAsymptomatic (const int a_idx,      /*!< Agent index */
 template <typename PTDType>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 bool isPresymptomatic (const int a_idx,      /*!< Agent index */
-		     const PTDType& a_ptd, /*!< Particle tile data */
-		     const int a_d /*!< Disease index */) {
+             const PTDType& a_ptd, /*!< Particle tile data */
+             const int a_d /*!< Disease index */) {
     return a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][a_idx] == SymptomStatus::presymptomatic;
 }
 

--- a/src/AgentDefinitions.H
+++ b/src/AgentDefinitions.H
@@ -287,8 +287,8 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 bool isNewlyHospitalized (const int a_idx,      /*!< Agent index */
                     const PTDType& a_ptd, /*!< Particle tile data */
                     const int a_d /*!< Disease index */) {
-    int delay = amrex::Math::floor(a_ptd.rdata(r0(a_d) + RealIdxDisease::hospital_delay)[a_idx]);
-    int incub = amrex::Math::floor(a_ptd.rdata(r0(a_d) + RealIdxDisease::incubation_period)[a_idx]);
+    amrex::Real delay = amrex::Math::floor(a_ptd.rdata(r0(a_d) + RealIdxDisease::hospital_delay)[a_idx]);
+    amrex::Real incub = amrex::Math::floor(a_ptd.rdata(r0(a_d) + RealIdxDisease::incubation_period)[a_idx]);
     if (isNewlySymptomatic(a_idx, a_ptd, a_d) && (delay == 0) && inHospital(a_idx, a_ptd)) {
         return true;
     } else if ((a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::status][a_idx] == Status::infected) &&

--- a/src/AgentDefinitions.H
+++ b/src/AgentDefinitions.H
@@ -200,6 +200,17 @@ bool isSymptomatic (const int a_idx,      /*!< Agent index */
     return a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][a_idx] == SymptomStatus::symptomatic;
 }
 
+/*! \brief Did the agent just become symptomatic this step? */
+template <typename PTDType>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+bool isNewlySymptomatic (const int a_idx,      /*!< Agent index */
+                    const PTDType& a_ptd, /*!< Particle tile data */
+                    const int a_d /*!< Disease index */) {
+    return (a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::status][a_idx] == Status::infected) &&
+	(a_ptd.rdata(r0(a_d) + RealIdxDisease::disease_counter)[a_idx] == amrex::Math::floor(a_ptd.rdata(r0(a_d) + RealIdxDisease::incubation_period)[a_idx])) &&
+	(a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][a_idx] == SymptomStatus::symptomatic);
+}
+
 /*! \brief Is an agent asymptomatic (does not currently have symptoms and will not develop them)? */
 template <typename PTDType>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE

--- a/src/AgentDefinitions.H
+++ b/src/AgentDefinitions.H
@@ -207,8 +207,8 @@ bool isNewlySymptomatic (const int a_idx,      /*!< Agent index */
                     const PTDType& a_ptd, /*!< Particle tile data */
                     const int a_d /*!< Disease index */) {
     return (a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::status][a_idx] == Status::infected) &&
-	(a_ptd.rdata(r0(a_d) + RealIdxDisease::disease_counter)[a_idx] == amrex::Math::floor(a_ptd.rdata(r0(a_d) + RealIdxDisease::incubation_period)[a_idx])) &&
-	(a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][a_idx] == SymptomStatus::symptomatic);
+    (a_ptd.rdata(r0(a_d) + RealIdxDisease::disease_counter)[a_idx] == amrex::Math::floor(a_ptd.rdata(r0(a_d) + RealIdxDisease::incubation_period)[a_idx])) &&
+    (a_ptd.m_runtime_idata[i0(a_d) + IntIdxDisease::symptomatic][a_idx] == SymptomStatus::symptomatic);
 }
 
 /*! \brief Is an agent asymptomatic (does not currently have symptoms and will not develop them)? */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -425,7 +425,7 @@ void runAgent () {
                     }
                     File << std::setw(12) << mmc[1];
                     File << std::setw(12) << mmc[2];
-                    for (int j = OutputStatus::R; j < OutputStatus::NewS; ++j) {
+                    for (int j = OutputStatus::R; j < OutputStatus::nattribs; ++j) {
                         File << std::setw(12) << counts[j];
                     }
                     // File << std::setw(12) << mmc[4];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,7 +155,7 @@ void runAgent () {
 
                 if (!File.good()) { amrex::FileOpenFailed(output_filename[d]); }
 
-                File << std::setw(5)  << "Day";
+                File << std::setw(5) << "Day";
                 File << std::setw(12) << "Su";
                 File << std::setw(12) << "PS/PI";
                 File << std::setw(12) << "S/PI";
@@ -368,10 +368,10 @@ void runAgent () {
                 if (Gpu::inLaunchRegion()) {
                     auto const& ma = disease_stats[d]->const_arrays();
                     GpuTuple<Real, Real, Real, Real, Real> mm =
-                        ParReduce(TypeList<ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum>{},
-                                  TypeList<Real, Real, Real, Real, Real>{}, *(disease_stats[d]), IntVect(0, 0),
+                            ParReduce(TypeList<ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum>{},
+                                      TypeList<Real, Real, Real, Real, Real>{}, *(disease_stats[d]), IntVect(0, 0),
                                       [=] AMREX_GPU_DEVICE (int box_no, int ii, int jj,
-                                                            int kk) noexcept -> GpuTuple<Real, Real, Real, Real, Real> {
+                                                           int kk) noexcept -> GpuTuple<Real, Real, Real, Real, Real> {
                                           return {ma[box_no](ii, jj, kk, 0), ma[box_no](ii, jj, kk, 1), ma[box_no](ii, jj, kk, 2),
                                                   ma[box_no](ii, jj, kk, 3), ma[box_no](ii, jj, kk, 4)};
                                       });
@@ -395,7 +395,7 @@ void runAgent () {
                             mmc[2] += dfab(ii, jj, kk, 2);
                             mmc[3] += dfab(ii, jj, kk, 3);
                             mmc[4] += dfab(ii, jj, kk, 4);
-                            });
+                        });
                     }
                 }
 
@@ -407,7 +407,7 @@ void runAgent () {
                     AMREX_ALWAYS_ASSERT(mmc[3] == counts[OutputStatus::D]);
 
                     // the total number of infected should equal the sum of
-            //     those that are hospitalized
+                    //     those that are hospitalized
                     //     exposed but not infectious
                     //     infectious and asymptomatic
                     //     infectious and pre-symptomatic
@@ -428,7 +428,7 @@ void runAgent () {
                     for (int j = OutputStatus::R; j < OutputStatus::NewS; ++j) {
                         File << std::setw(12) << counts[j];
                     }
-                    //File << std::setw(12) << mmc[4];
+                    // File << std::setw(12) << mmc[4];
                     File << "\n";
 
                     File.flush();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -401,11 +401,12 @@ void runAgent () {
                     AMREX_ALWAYS_ASSERT(mmc[3] == counts[4]);
 
                     // the total number of infected should equal the sum of
+		    //     those that are hospitalized
                     //     exposed but not infectious
                     //     infectious and asymptomatic
                     //     infectious and pre-symptomatic
                     //     infectious and symptomatic
-                    AMREX_ALWAYS_ASSERT(counts[1] == counts[5] + counts[6] + counts[7] + counts[8]);
+                    AMREX_ALWAYS_ASSERT(counts[1] == mmc[0] + counts[5] + counts[6] + counts[7] + counts[8]);
 
                     std::ofstream File;
                     File.open(output_filename[d].c_str(), std::ios::out | std::ios::app);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -407,7 +407,7 @@ void runAgent () {
                     AMREX_ALWAYS_ASSERT(mmc[3] == counts[OutputStatus::D]);
 
                     // the total number of infected should equal the sum of
-		    //     those that are hospitalized
+            //     those that are hospitalized
                     //     exposed but not infectious
                     //     infectious and asymptomatic
                     //     infectious and pre-symptomatic

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,18 +155,22 @@ void runAgent () {
 
                 if (!File.good()) { amrex::FileOpenFailed(output_filename[d]); }
 
-                File << std::setw(5) << "Day";
-                File << std::setw(12) << "Susceptible";
-                File << std::setw(12) << "Infected";
-                File << std::setw(12) << "Recovered";
-                File << std::setw(12) << "Deaths";
-                File << std::setw(15) << "Hospitalized";
-                File << std::setw(15) << "ICU";
-                File << std::setw(12) << "Ventilated";
-                File << std::setw(12) << "Exposed";
-                File << std::setw(15) << "Asymptomatic";
-                File << std::setw(15) << "Presymptomatic";
-                File << std::setw(15) << "Symptomatic\n";
+                File << std::setw(5)  << "Day";
+                File << std::setw(12) << "Su";
+                File << std::setw(12) << "PS/PI";
+                File << std::setw(12) << "S/PI";
+                File << std::setw(12) << "PS/I";
+                File << std::setw(12) << "S/I";
+                File << std::setw(12) << "A/PI";
+                File << std::setw(12) << "A/I";
+                File << std::setw(12) << "H/NI";
+                File << std::setw(12) << "H/I";
+                File << std::setw(12) << "ICU";
+                File << std::setw(12) << "V";
+                File << std::setw(12) << "R";
+                File << std::setw(12) << "D";
+                File << std::setw(12) << "NewS";
+                File << std::setw(12) << "NewH\n";
 
                 File.flush();
 
@@ -300,11 +304,11 @@ void runAgent () {
     std::vector<Long> cumulative_deaths(params.num_diseases, 0);
     for (int d = 0; d < params.num_diseases; d++) {
         auto counts = pc.getTotals(d);
-        if (counts[1] > num_infected_peak[d]) {
-            num_infected_peak[d] = counts[1];
+        if (totalExposed(counts) > num_infected_peak[d]) {
+            num_infected_peak[d] = totalExposed(counts);
             step_of_peak[d] = 0;
         }
-        cumulative_deaths[d] = counts[4];
+        cumulative_deaths[d] = counts[OutputStatus::D];
     }
 
     Vector<Long> num_infected(params.num_diseases, 0);
@@ -352,34 +356,35 @@ void runAgent () {
 
             for (int d = 0; d < params.num_diseases; d++) {
                 auto counts = pc.getTotals(d);
-                if (counts[1] > num_infected_peak[d]) {
-                    num_infected_peak[d] = counts[1];
+                if (totalExposed(counts) > num_infected_peak[d]) {
+                    num_infected_peak[d] = totalExposed(counts);
                     step_of_peak[d] = i;
                 }
-                cumulative_deaths[d] = counts[4];
-                num_infected[d] = counts[1];
+                cumulative_deaths[d] = counts[OutputStatus::D];
+                num_infected[d] = totalExposed(counts);
 
-                Real mmc[4] = {0, 0, 0, 0};
+                Real mmc[5] = {0, 0, 0, 0, 0};
 #ifdef AMREX_USE_GPU
                 if (Gpu::inLaunchRegion()) {
                     auto const& ma = disease_stats[d]->const_arrays();
-                    GpuTuple<Real, Real, Real, Real> mm =
-                            ParReduce(TypeList<ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum>{},
-                                      TypeList<Real, Real, Real, Real>{}, *(disease_stats[d]), IntVect(0, 0),
+                    GpuTuple<Real, Real, Real, Real, Real> mm =
+                        ParReduce(TypeList<ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum, ReduceOpSum>{},
+                                  TypeList<Real, Real, Real, Real, Real>{}, *(disease_stats[d]), IntVect(0, 0),
                                       [=] AMREX_GPU_DEVICE (int box_no, int ii, int jj,
-                                                           int kk) noexcept -> GpuTuple<Real, Real, Real, Real> {
+                                                            int kk) noexcept -> GpuTuple<Real, Real, Real, Real, Real> {
                                           return {ma[box_no](ii, jj, kk, 0), ma[box_no](ii, jj, kk, 1), ma[box_no](ii, jj, kk, 2),
-                                                  ma[box_no](ii, jj, kk, 3)};
+                                                  ma[box_no](ii, jj, kk, 3), ma[box_no](ii, jj, kk, 4)};
                                       });
                     mmc[0] = amrex::get<0>(mm);
                     mmc[1] = amrex::get<1>(mm);
                     mmc[2] = amrex::get<2>(mm);
                     mmc[3] = amrex::get<3>(mm);
+                    mmc[4] = amrex::get<4>(mm);
                 } else
 #endif
                 {
 #ifdef AMREX_USE_OMP
-#pragma omp parallel if (!system::regtest_reduction) reduction(+ : mmc[ : 4])
+#pragma omp parallel if (!system::regtest_reduction) reduction(+ : mmc[ : 5])
 #endif
                     for (MFIter mfi(*(disease_stats[d])); mfi.isValid(); ++mfi) {
                         Box const& bx = mfi.tilebox();
@@ -389,16 +394,17 @@ void runAgent () {
                             mmc[1] += dfab(ii, jj, kk, 1);
                             mmc[2] += dfab(ii, jj, kk, 2);
                             mmc[3] += dfab(ii, jj, kk, 3);
-                        });
+                            mmc[4] += dfab(ii, jj, kk, 4);
+                            });
                     }
                 }
 
-                ParallelDescriptor::ReduceRealSum(&mmc[0], 4, ParallelDescriptor::IOProcessorNumber());
+                ParallelDescriptor::ReduceRealSum(&mmc[0], 5, ParallelDescriptor::IOProcessorNumber());
 
                 if (ParallelDescriptor::IOProcessor()) {
                     // total number of deaths computed on agents and on mesh should be the same...
-                    if (mmc[3] != counts[4]) { amrex::Print() << mmc[3] << " " << counts[4] << "\n"; }
-                    AMREX_ALWAYS_ASSERT(mmc[3] == counts[4]);
+                    if (mmc[3] != counts[OutputStatus::D]) { amrex::Print() << mmc[3] << " " << counts[OutputStatus::D] << "\n"; }
+                    AMREX_ALWAYS_ASSERT(mmc[3] == counts[OutputStatus::D]);
 
                     // the total number of infected should equal the sum of
 		    //     those that are hospitalized
@@ -406,7 +412,7 @@ void runAgent () {
                     //     infectious and asymptomatic
                     //     infectious and pre-symptomatic
                     //     infectious and symptomatic
-                    AMREX_ALWAYS_ASSERT(counts[1] == mmc[0] + counts[5] + counts[6] + counts[7] + counts[8]);
+                    // AMREX_ALWAYS_ASSERT(counts[1] == mmc[0] + counts[5] + counts[6] + counts[7] + counts[8]);
 
                     std::ofstream File;
                     File.open(output_filename[d].c_str(), std::ios::out | std::ios::app);
@@ -414,17 +420,16 @@ void runAgent () {
                     if (!File.good()) { amrex::FileOpenFailed(output_filename[d]); }
 
                     File << std::setw(5) << i;
-                    File << std::setw(12) << counts[0];
-                    File << std::setw(12) << counts[1];
-                    File << std::setw(12) << counts[2];
-                    File << std::setw(12) << counts[4];
-                    File << std::setw(15) << mmc[0];
-                    File << std::setw(15) << mmc[1];
+                    for (int j = 0; j < OutputStatus::ICU; ++j) {
+                        File << std::setw(12) << counts[j];
+                    }
+                    File << std::setw(12) << mmc[1];
                     File << std::setw(12) << mmc[2];
-                    File << std::setw(12) << counts[5];
-                    File << std::setw(15) << counts[6];
-                    File << std::setw(15) << counts[7];
-                    File << std::setw(15) << counts[8] << "\n";
+                    for (int j = OutputStatus::R; j < OutputStatus::NewS; ++j) {
+                        File << std::setw(12) << counts[j];
+                    }
+                    //File << std::setw(12) << mmc[4];
+                    File << "\n";
 
                     File.flush();
 


### PR DESCRIPTION
This updates the summary `output.dat` files to be consistent with the compartmental model.

The new output looks like:

```
   Day          Su       PS/PI        S/PI        PS/I         S/I        A/PI         A/I        H/NI         H/I         ICU           V           R           D        NewS       NewH
    0    33991657           3           0           0           0           2           0           0           0           0           0           0           0           0           0
    1    33991657           1           1           0           0           2           0           1           0           1           0           0           0           2           1
    2    33991657           0           2           0           0           1           1           0           1           1           0           0           0           1           0
    3    33991655           1           1           0           1           1           2           0           1           1           0           0           0           0           0
    4    33991652           3           1           0           1           2           2           0           0           0           0           1           0           0           0
    5    33991645           7           0           0           2           5           2           0           0           0           0           1           0           0           0
    6    33991639           5           1           1           4           8           3           0           0           0           0           1           0           3           0
    7    33991630           7           1           1           7          11           4           0           0           0           0           1           0           3           0
    8    33991619          12           1           1           9          11           6           0           1           0           0           2           0           3           1
    9    33991609           9           4           2          12           8          13           0           1           0           0           4           0           7           0
   10    33991571          26           6           2          17          21          14           0           0           0           0           5           0           7           0
   11    33991535          38           8           3          24          29          20           0           0           0           0           5           0           9           0
   12    33991459          59          12           8          30          53          29           0           1           0           0          11           0          15           1
   13    33991383          72          22          14          42          67          44           0           1           0           0          17           0          26           0
   14    33991266         115          26          19          60          89          62           2           2           1           0          21           0          28           3
   15    33991107         135          42          32          93         127          88           4           3           2           0          31           0          54           3
   16    33988685        1511          57          40         138        1055         131           3           4           1           0          38           0          65           1
   17    33973621        9720         452         211         288        6887         361          42          22          17           3          58           0         613          58
   18    33760261      132241        3043        1725        1214       90460        2079         421         137         180          45          81           0        4023         495
   19    33247591      372455       40241       15192       11326      278957       18713        5517        1550        2464         513         120           0       53840        6511
   20    32333838      719786      125901       55191       65614      575085       87590       17996       10431        9710        2009         228           2      161389       21415
   21    32313579      335525      255942      127523      213660      419148      251595       37696       36288       25247        5268         693          13      324079       45952
   22    32264732      119705      181530      167300      451185      221252      468862       31717       78666       37723        7900        6552         161      205326       42049
```