### PR TITLE
Add --version runtime argument

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,38 @@ void overrideAmrexDefaults () {
 /*! \brief Main function: initializes AMReX, calls runAgent(), finalizes AMReX */
 int main (int argc, /*!< Number of command line arguments */
           char* argv[] /*!< Command line arguments */) {
+
+    int my_rank;
+#ifdef AMREX_USE_MPI
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
+#else
+    my_rank = 0;
+#endif
+
+    if (argc < 2) {
+        if (my_rank == 0) {
+            std::cout << "Usage: \n"
+                      << "Either run ./agent --version to print the ExaEpi and AMReX versions, or \n"
+                      << "           ./agent <inputs_file> <optional> <command> <line> <arguments> to run the model. \n";
+        }
+#ifdef AMREX_USE_MPI
+        MPI_Finalize();
+#endif
+        return 0;
+    }
+
+    if (std::string(argv[1]) == "--version") {
+        if (my_rank == 0) {
+            std::cout << "AMReX version " << amrex::Version() << "\n";
+            std::cout << "ExaEpi version " << EXAEPI_VERSION << " (built on " << __DATE__ << ")\n";
+        }
+#ifdef AMREX_USE_MPI
+        MPI_Finalize();
+#endif
+        return 0;
+    }
+
     amrex::Initialize(argc, argv, true, MPI_COMM_WORLD, overrideAmrexDefaults);
 
     Print() << "ExaEpi version " << EXAEPI_VERSION << " (built on " << __DATE__ << ")\n";
@@ -52,6 +84,10 @@ int main (int argc, /*!< Number of command line arguments */
     runAgent();
 
     amrex::Finalize();
+
+#ifdef AMREX_USE_MPI
+    MPI_Finalize();
+#endif
 }
 
 /*! \brief Run agent-based simulation:


### PR DESCRIPTION
This prints some usage instructions / version information about the executable and exits. Output:

```
mpirun -np 2 ./agent
Usage:
Either run ./agent --version to print the ExaEpi and AMReX versions, or
           ./agent <inputs_file> <optional> <command> <line> <arguments> to run the model
```

```
mpirun -np 2 ./agent --version
AMReX version 25.08-7-gc254bcc6ee75
ExaEpi version 25.04-12-g1b34acf-g1b34acf (version) (built on Aug 12 2025)
```

```
mpirun -np 2 ./agent inputs_random_ca
<runs normally>
```