### PR TITLE
Implement relative infectiousness for asymptomatic individuals

### DIFF
--- a/docs/source/usage/how_to_run.rst
+++ b/docs/source/usage/how_to_run.rst
@@ -130,7 +130,6 @@ The following inputs specify the disease parameters:
     The fraction of cases that are asymptomatic. There must be one entry for each disease strain.
 * ``disease.asymp_relative_inf`` (`float`, default ``0.75``)
     The relative infectiousness of asymptomatic individuals, from 0 to 1. There must be one entry for each disease strain.
-    `This is not yet implemented`.
 * ``disease.vac_eff`` (`float`, default ``0``)
     The vaccine efficacy - the probability of transmission will be multiplied by one minus this factor.
     `Vaccination is not yet implemented, so this factor must be left at 0`.

--- a/examples/inputs.defaults
+++ b/examples/inputs.defaults
@@ -87,7 +87,7 @@ disease.num_initial_cases = 0
 disease.p_trans = 0.2
 # Probability of being asymptomatic.
 disease.p_asymp = 0.4
-# Relative infectiousness of asymptomatic indivudals. Curnently not implemented.
+# Relative infectiousness of asymptomatic individuals.
 disease.asymp_relative_inf = 0.75
 # Vaccine efficacy. Not yet implemented; leave at 0.
 disease.vac_eff = 0

--- a/src/InteractionModAirTravel.H
+++ b/src/InteractionModAirTravel.H
@@ -21,7 +21,7 @@ static void binaryInteractionAirTravel (const int a_i,                    /*!< I
                                         const int a_j,                    /*!< Index of susceptible agent */
                                         const PTDType& a_ptd_i,           /*!< Particle tile data for infectious agent */
                                         const PTDType& a_ptd_j,           /*!< Particle tile data for susceptible agent*/
-                                        const DiseaseParm* const a_lparm, /*!< disease paramters */
+                                        const DiseaseParm* const a_lparm, /*!< disease parameters */
                                         const Real a_social_scale,        /*!< Social scale */
                                         ParticleReal* const a_prob_ptr /*!< infection probability */) {
     Real infect = a_lparm->infect;

--- a/src/InteractionModHome.H
+++ b/src/InteractionModHome.H
@@ -150,9 +150,9 @@ void InteractionModHome<PCType, PTDType, PType>::fastInteractHome (PCType& agent
             auto infected_family_not_withdrawn_d_ptr = infected_family_not_withdrawn_d[OMP_THREAD_NUM].data();
             auto infected_nc_d_ptr = infected_nc_d[OMP_THREAD_NUM].data();
 
-            auto infected_family_asymp_d_ptr = infected_family_d[OMP_THREAD_NUM].data();
-            auto infected_family_not_withdrawn_asymp_d_ptr = infected_family_not_withdrawn_d[OMP_THREAD_NUM].data();
-            auto infected_nc_asymp_d_ptr = infected_nc_d[OMP_THREAD_NUM].data();
+            auto infected_family_asymp_d_ptr = infected_family_asymp_d[OMP_THREAD_NUM].data();
+            auto infected_family_not_withdrawn_asymp_d_ptr = infected_family_not_withdrawn_asymp_d[OMP_THREAD_NUM].data();
+            auto infected_nc_asymp_d_ptr = infected_nc_asymp_d[OMP_THREAD_NUM].data();
 
             for (int d = 0; d < n_disease; d++) {
                 // calculate separately for infected children and infected adults, since they have different transmission rates

--- a/src/InteractionModHome.H
+++ b/src/InteractionModHome.H
@@ -179,20 +179,20 @@ void InteractionModHome<PCType, PTDType, PType>::fastInteractHome (PCType& agent
                             auto community = getCommunityIndex(ptd, i);
                             AMREX_ALWAYS_ASSERT(community <= max_communities);
                             int family_i = community * max_family + family_ptr[i];
-                            if (isAsymptomatic(i, ptd, d)) {
+                            if (isAsymptomatic(i, ptd, d) || isPresymptomatic(i, ptd, d)) {
                                 Gpu::Atomic::AddNoRet(&infected_family_asymp_d_ptr[family_i], 1);
                             } else {
                                 Gpu::Atomic::AddNoRet(&infected_family_d_ptr[family_i], 1);
                             }
                             if (!ptd.m_idata[IntIdx::withdrawn][i]) {
-                                if (isAsymptomatic(i, ptd, d)) {
+                                if (isAsymptomatic(i, ptd, d) || isPresymptomatic(i, ptd, d)) {
                                     Gpu::Atomic::AddNoRet(&infected_family_not_withdrawn_asymp_d_ptr[family_i], 1);
                                 } else {
                                     Gpu::Atomic::AddNoRet(&infected_family_not_withdrawn_d_ptr[family_i], 1);
                                 }
                                 int cluster = family_ptr[i] / FAMILIES_PER_CLUSTER;
                                 int nc = (community * max_nborhood + nborhood_ptr[i]) * num_ncs + cluster;
-                                if (isAsymptomatic(i, ptd, d)) {
+                                if (isAsymptomatic(i, ptd, d) || isPresymptomatic(i, ptd, d)) {
                                     Gpu::Atomic::AddNoRet(&infected_nc_asymp_d_ptr[nc], 1);
                                 } else {
                                     Gpu::Atomic::AddNoRet(&infected_nc_d_ptr[nc], 1);

--- a/src/InteractionModHome.H
+++ b/src/InteractionModHome.H
@@ -24,7 +24,7 @@ struct BinaryInteractionHome {
     ParticleReal operator()(const int infectious_i,           /*!< Index of infectious agent */
                             const int susceptible_i,          /*!< Index of susceptible agent */
                             const PTDType& a_ptd,             /*!< Particle tile data */
-                            const DiseaseParm* const a_lparm, /*!< disease paramters */
+                            const DiseaseParm* const a_lparm, /*!< disease parameters */
                             const Real a_social_scale /*!< Social scale */) const noexcept {
         auto age_group_ptr = a_ptd.m_idata[IntIdx::age_group];
         auto family_ptr = a_ptd.m_idata[IntIdx::family];

--- a/src/InteractionModHome.H
+++ b/src/InteractionModHome.H
@@ -101,6 +101,9 @@ void InteractionModHome<PCType, PTDType, PType>::fastInteractHome (PCType& agent
     Vector<Gpu::DeviceVector<int>> infected_family_d(OMP_MAX_THREADS);
     Vector<Gpu::DeviceVector<int>> infected_family_not_withdrawn_d(OMP_MAX_THREADS);
     Vector<Gpu::DeviceVector<int>> infected_nc_d(OMP_MAX_THREADS);
+    Vector<Gpu::DeviceVector<int>> infected_family_asymp_d(OMP_MAX_THREADS);
+    Vector<Gpu::DeviceVector<int>> infected_family_not_withdrawn_asymp_d(OMP_MAX_THREADS);
+    Vector<Gpu::DeviceVector<int>> infected_nc_asymp_d(OMP_MAX_THREADS);
 
     for (int lev = 0; lev < agents.numLevels(); ++lev) {
 #ifdef AMREX_USE_OMP
@@ -139,9 +142,17 @@ void InteractionModHome<PCType, PTDType, PType>::fastInteractHome (PCType& agent
             infected_family_not_withdrawn_d[OMP_THREAD_NUM].resize(max_communities * max_family);
             infected_nc_d[OMP_THREAD_NUM].resize(max_communities * num_ncs * max_nborhood);
 
+            infected_family_asymp_d[OMP_THREAD_NUM].resize(max_communities * max_family);
+            infected_family_not_withdrawn_asymp_d[OMP_THREAD_NUM].resize(max_communities * max_family);
+            infected_nc_asymp_d[OMP_THREAD_NUM].resize(max_communities * num_ncs * max_nborhood);
+
             auto infected_family_d_ptr = infected_family_d[OMP_THREAD_NUM].data();
             auto infected_family_not_withdrawn_d_ptr = infected_family_not_withdrawn_d[OMP_THREAD_NUM].data();
             auto infected_nc_d_ptr = infected_nc_d[OMP_THREAD_NUM].data();
+
+            auto infected_family_asymp_d_ptr = infected_family_d[OMP_THREAD_NUM].data();
+            auto infected_family_not_withdrawn_asymp_d_ptr = infected_family_not_withdrawn_d[OMP_THREAD_NUM].data();
+            auto infected_nc_asymp_d_ptr = infected_nc_d[OMP_THREAD_NUM].data();
 
             for (int d = 0; d < n_disease; d++) {
                 // calculate separately for infected children and infected adults, since they have different transmission rates
@@ -152,6 +163,10 @@ void InteractionModHome<PCType, PTDType, PType>::fastInteractHome (PCType& agent
                         devMemset(infected_family_not_withdrawn_d_ptr, 0,
                                   infected_family_not_withdrawn_d[OMP_THREAD_NUM].size() * sizeof(int));
                         devMemset(infected_nc_d_ptr, 0, infected_nc_d[OMP_THREAD_NUM].size() * sizeof(int));
+                        devMemset(infected_family_asymp_d_ptr, 0, infected_family_asymp_d[OMP_THREAD_NUM].size() * sizeof(int));
+                        devMemset(infected_family_not_withdrawn_asymp_d_ptr, 0,
+                                  infected_family_not_withdrawn_asymp_d[OMP_THREAD_NUM].size() * sizeof(int));
+                        devMemset(infected_nc_asymp_d_ptr, 0, infected_nc_asymp_d[OMP_THREAD_NUM].size() * sizeof(int));
                     }
                     auto prob_ptr = soa.GetRealData(RealIdx::nattribs + r0(d) + RealIdxDisease::prob).data();
                     auto lparm = agents.getDiseaseParameters_d(d);
@@ -164,12 +179,24 @@ void InteractionModHome<PCType, PTDType, PType>::fastInteractHome (PCType& agent
                             auto community = getCommunityIndex(ptd, i);
                             AMREX_ALWAYS_ASSERT(community <= max_communities);
                             int family_i = community * max_family + family_ptr[i];
-                            Gpu::Atomic::AddNoRet(&infected_family_d_ptr[family_i], 1);
+                            if (isAsymptomatic(i, ptd, d)) {
+                                Gpu::Atomic::AddNoRet(&infected_family_asymp_d_ptr[family_i], 1);
+                            } else {
+                                Gpu::Atomic::AddNoRet(&infected_family_d_ptr[family_i], 1);
+                            }
                             if (!ptd.m_idata[IntIdx::withdrawn][i]) {
-                                Gpu::Atomic::AddNoRet(&infected_family_not_withdrawn_d_ptr[family_i], 1);
+                                if (isAsymptomatic(i, ptd, d)) {
+                                    Gpu::Atomic::AddNoRet(&infected_family_not_withdrawn_asymp_d_ptr[family_i], 1);
+                                } else {
+                                    Gpu::Atomic::AddNoRet(&infected_family_not_withdrawn_d_ptr[family_i], 1);
+                                }
                                 int cluster = family_ptr[i] / FAMILIES_PER_CLUSTER;
                                 int nc = (community * max_nborhood + nborhood_ptr[i]) * num_ncs + cluster;
-                                Gpu::Atomic::AddNoRet(&infected_nc_d_ptr[nc], 1);
+                                if (isAsymptomatic(i, ptd, d)) {
+                                    Gpu::Atomic::AddNoRet(&infected_nc_asymp_d_ptr[nc], 1);
+                                } else {
+                                    Gpu::Atomic::AddNoRet(&infected_nc_d_ptr[nc], 1);
+                                }
                             }
                         }
                     });
@@ -193,8 +220,11 @@ void InteractionModHome<PCType, PTDType, PType>::fastInteractHome (PCType& agent
                             AMREX_ALWAYS_ASSERT(community <= max_communities);
                             int family_i = community * max_family + family_ptr[i];
                             int num_infected_family = infected_family_d_ptr[family_i];
+                            int num_infected_family_asymp = infected_family_asymp_d_ptr[family_i];
                             Real family_prob = 1.0_rt - infect * xmit_family_prob * scale;
+                            Real family_prob_asymp = 1.0_rt - lparm->asymp_relative_inf*infect * xmit_family_prob * scale;
                             prob_ptr[i] *= static_cast<ParticleReal>(std::pow(family_prob, num_infected_family));
+                            prob_ptr[i] *= static_cast<ParticleReal>(std::pow(family_prob_asymp, num_infected_family_asymp));
                             if (!ptd.m_idata[IntIdx::withdrawn][i]) {
                                 int num_infected_family_not_withdrawn = infected_family_not_withdrawn_d_ptr[family_i];
                                 AMREX_ALWAYS_ASSERT(num_infected_family >= num_infected_family_not_withdrawn);
@@ -204,6 +234,14 @@ void InteractionModHome<PCType, PTDType, PType>::fastInteractHome (PCType& agent
                                 AMREX_ALWAYS_ASSERT(num_infected_nc >= 0);
                                 Real nc_prob = 1.0_rt - infect * xmit_nc_prob * scale;
                                 prob_ptr[i] *= static_cast<ParticleReal>(std::pow(nc_prob, num_infected_nc));
+
+                                // same for asymptomatic
+                                int num_infected_family_not_withdrawn_asymp = infected_family_not_withdrawn_asymp_d_ptr[family_i];
+                                AMREX_ALWAYS_ASSERT(num_infected_family_asymp >= num_infected_family_not_withdrawn_asymp);
+                                int num_infected_nc_asymp = infected_nc_asymp_d_ptr[nc] - num_infected_family_not_withdrawn_asymp;
+                                AMREX_ALWAYS_ASSERT(num_infected_nc_asymp >= 0);
+                                Real nc_prob_asymp = 1.0_rt - lparm->asymp_relative_inf * infect * xmit_nc_prob * scale;
+                                prob_ptr[i] *= static_cast<ParticleReal>(std::pow(nc_prob_asymp, num_infected_nc_asymp));
                             }
                         }
                     });

--- a/src/InteractionModHome.H
+++ b/src/InteractionModHome.H
@@ -222,7 +222,7 @@ void InteractionModHome<PCType, PTDType, PType>::fastInteractHome (PCType& agent
                             int num_infected_family = infected_family_d_ptr[family_i];
                             int num_infected_family_asymp = infected_family_asymp_d_ptr[family_i];
                             Real family_prob = 1.0_rt - infect * xmit_family_prob * scale;
-                            Real family_prob_asymp = 1.0_rt - lparm->asymp_relative_inf*infect * xmit_family_prob * scale;
+                            Real family_prob_asymp = 1.0_rt - lparm->asymp_relative_inf * infect * xmit_family_prob * scale;
                             prob_ptr[i] *= static_cast<ParticleReal>(std::pow(family_prob, num_infected_family));
                             prob_ptr[i] *= static_cast<ParticleReal>(std::pow(family_prob_asymp, num_infected_family_asymp));
                             if (!ptd.m_idata[IntIdx::withdrawn][i]) {

--- a/src/InteractionModHomeNborhood.H
+++ b/src/InteractionModHomeNborhood.H
@@ -87,6 +87,9 @@ void InteractionModHomeNborhood<PCType, PTDType, PType>::fastInteractHomeNborhoo
     Vector<Gpu::DeviceVector<int>> infected_community_d(OMP_MAX_THREADS);
     Vector<Gpu::DeviceVector<int>> infected_nborhood_d(OMP_MAX_THREADS);
 
+    Vector<Gpu::DeviceVector<int>> infected_community_asymp_d(OMP_MAX_THREADS);
+    Vector<Gpu::DeviceVector<int>> infected_nborhood_asymp_d(OMP_MAX_THREADS);
+
     for (int lev = 0; lev < agents.numLevels(); ++lev) {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -109,8 +112,13 @@ void InteractionModHomeNborhood<PCType, PTDType, PType>::fastInteractHomeNborhoo
 
             infected_community_d[OMP_THREAD_NUM].resize(max_communities);
             infected_nborhood_d[OMP_THREAD_NUM].resize(max_communities * max_nborhood);
+            infected_community_asymp_d[OMP_THREAD_NUM].resize(max_communities);
+            infected_nborhood_asymp_d[OMP_THREAD_NUM].resize(max_communities * max_nborhood);
             auto infected_community_d_ptr = infected_community_d[OMP_THREAD_NUM].data();
             auto infected_nborhood_d_ptr = infected_nborhood_d[OMP_THREAD_NUM].data();
+
+            auto infected_community_asymp_d_ptr = infected_community_asymp_d[OMP_THREAD_NUM].data();
+            auto infected_nborhood_asymp_d_ptr = infected_nborhood_asymp_d[OMP_THREAD_NUM].data();
 
             /*
             Print() << mfi.tilebox() << " np " << np << " max communities " << max_communities
@@ -121,6 +129,8 @@ void InteractionModHomeNborhood<PCType, PTDType, PType>::fastInteractHomeNborhoo
             for (int d = 0; d < n_disease; d++) {
                 devMemset(infected_community_d_ptr, 0, infected_community_d[OMP_THREAD_NUM].size() * sizeof(int));
                 devMemset(infected_nborhood_d_ptr, 0, infected_nborhood_d[OMP_THREAD_NUM].size() * sizeof(int));
+                devMemset(infected_community_asymp_d_ptr, 0, infected_community_asymp_d[OMP_THREAD_NUM].size() * sizeof(int));
+                devMemset(infected_nborhood_asymp_d_ptr, 0, infected_nborhood_asymp_d[OMP_THREAD_NUM].size() * sizeof(int));
 
                 auto prob_ptr = soa.GetRealData(RealIdx::nattribs + r0(d) + RealIdxDisease::prob).data();
                 auto lparm = agents.getDiseaseParameters_d(d);
@@ -132,8 +142,13 @@ void InteractionModHomeNborhood<PCType, PTDType, PType>::fastInteractHomeNborhoo
                     if (isInfectious(i, ptd, d) && isCandidate(i, ptd)) {
                         auto community = getCommunityIndex(ptd, i);
                         auto nborhood = nborhood_ptr[i];
-                        Gpu::Atomic::AddNoRet(&infected_community_d_ptr[community], 1);
-                        Gpu::Atomic::AddNoRet(&infected_nborhood_d_ptr[community * max_nborhood + nborhood], 1);
+                        if (isAsymptomatic(i, ptd, d)) {
+                            Gpu::Atomic::AddNoRet(&infected_community_asymp_d_ptr[community], 1);
+                            Gpu::Atomic::AddNoRet(&infected_nborhood_asymp_d_ptr[community * max_nborhood + nborhood], 1);
+                        } else {
+                            Gpu::Atomic::AddNoRet(&infected_community_d_ptr[community], 1);
+                            Gpu::Atomic::AddNoRet(&infected_nborhood_d_ptr[community * max_nborhood + nborhood], 1);
+                        }
                     }
                 });
                 Gpu::synchronize();
@@ -144,12 +159,20 @@ void InteractionModHomeNborhood<PCType, PTDType, PType>::fastInteractHomeNborhoo
                         auto nborhood = nborhood_ptr[i];
                         int num_infected_nborhood = infected_nborhood_d_ptr[community * max_nborhood + nborhood];
                         int num_infected_community = infected_community_d_ptr[community];
+                        int num_infected_nborhood_asymp = infected_nborhood_asymp_d_ptr[community * max_nborhood + nborhood];
+                        int num_infected_community_asymp = infected_community_asymp_d_ptr[community];
                         AMREX_ALWAYS_ASSERT(num_infected_community >= num_infected_nborhood);
                         Real comm_prob = 1.0_prt - infect * lparm->xmit_comm[ptd.m_idata[IntIdx::age_group][i]] * scale;
                         prob_ptr[i] *=
                                 static_cast<ParticleReal>(std::pow(comm_prob, num_infected_community - num_infected_nborhood));
                         Real nborhood_prob = 1.0_prt - infect * lparm->xmit_hood[ptd.m_idata[IntIdx::age_group][i]] * scale;
                         prob_ptr[i] *= static_cast<ParticleReal>(std::pow(nborhood_prob, num_infected_nborhood));
+                        Real comm_prob_asymp = 1.0_prt - lparm->asymp_relative_inf * infect * lparm->xmit_comm[ptd.m_idata[IntIdx::age_group][i]] * scale;
+                        prob_ptr[i] *=
+                                static_cast<ParticleReal>(std::pow(comm_prob_asymp, num_infected_community_asymp - num_infected_nborhood_asymp));
+                        Real nborhood_prob_asymp = 1.0_prt - lparm->asymp_relative_inf * infect * lparm->xmit_hood[ptd.m_idata[IntIdx::age_group][i]] * scale;
+                        prob_ptr[i] *= static_cast<ParticleReal>(std::pow(nborhood_prob_asymp, num_infected_nborhood_asymp));
+
                     }
                 });
                 Gpu::synchronize();

--- a/src/InteractionModHomeNborhood.H
+++ b/src/InteractionModHomeNborhood.H
@@ -142,7 +142,7 @@ void InteractionModHomeNborhood<PCType, PTDType, PType>::fastInteractHomeNborhoo
                     if (isInfectious(i, ptd, d) && isCandidate(i, ptd)) {
                         auto community = getCommunityIndex(ptd, i);
                         auto nborhood = nborhood_ptr[i];
-                        if (isAsymptomatic(i, ptd, d)) {
+                        if (isAsymptomatic(i, ptd, d) || isPresymptomatic(i, ptd, d)) {
                             Gpu::Atomic::AddNoRet(&infected_community_asymp_d_ptr[community], 1);
                             Gpu::Atomic::AddNoRet(&infected_nborhood_asymp_d_ptr[community * max_nborhood + nborhood], 1);
                         } else {

--- a/src/InteractionModHomeNborhood.H
+++ b/src/InteractionModHomeNborhood.H
@@ -23,7 +23,7 @@ struct BinaryInteractionHomeNborhood {
     ParticleReal operator()(const int infectious_i,           /*!< Index of infectious agent */
                             const int susceptible_i,          /*!< Index of susceptible agent */
                             const PTDType& a_ptd,             /*!< Particle tile data */
-                            const DiseaseParm* const a_lparm, /*!< disease paramters */
+                            const DiseaseParm* const a_lparm, /*!< disease parameters */
                             const Real a_social_scale /*!< Social scale */) const noexcept {
         auto nborhood_ptr = a_ptd.m_idata[IntIdx::nborhood];
 

--- a/src/InteractionModHomeNborhood.H
+++ b/src/InteractionModHomeNborhood.H
@@ -167,12 +167,13 @@ void InteractionModHomeNborhood<PCType, PTDType, PType>::fastInteractHomeNborhoo
                                 static_cast<ParticleReal>(std::pow(comm_prob, num_infected_community - num_infected_nborhood));
                         Real nborhood_prob = 1.0_prt - infect * lparm->xmit_hood[ptd.m_idata[IntIdx::age_group][i]] * scale;
                         prob_ptr[i] *= static_cast<ParticleReal>(std::pow(nborhood_prob, num_infected_nborhood));
-                        Real comm_prob_asymp = 1.0_prt - lparm->asymp_relative_inf * infect * lparm->xmit_comm[ptd.m_idata[IntIdx::age_group][i]] * scale;
-                        prob_ptr[i] *=
-                                static_cast<ParticleReal>(std::pow(comm_prob_asymp, num_infected_community_asymp - num_infected_nborhood_asymp));
-                        Real nborhood_prob_asymp = 1.0_prt - lparm->asymp_relative_inf * infect * lparm->xmit_hood[ptd.m_idata[IntIdx::age_group][i]] * scale;
+                        Real comm_prob_asymp = 1.0_prt - lparm->asymp_relative_inf * infect *
+                                                                 lparm->xmit_comm[ptd.m_idata[IntIdx::age_group][i]] * scale;
+                        prob_ptr[i] *= static_cast<ParticleReal>(
+                                std::pow(comm_prob_asymp, num_infected_community_asymp - num_infected_nborhood_asymp));
+                        Real nborhood_prob_asymp = 1.0_prt - lparm->asymp_relative_inf * infect *
+                                                                     lparm->xmit_hood[ptd.m_idata[IntIdx::age_group][i]] * scale;
                         prob_ptr[i] *= static_cast<ParticleReal>(std::pow(nborhood_prob_asymp, num_infected_nborhood_asymp));
-
                     }
                 });
                 Gpu::synchronize();

--- a/src/InteractionModSchool.H
+++ b/src/InteractionModSchool.H
@@ -21,7 +21,7 @@ struct BinaryInteractionSchool {
     ParticleReal operator()(const int infectious_i,           /*!< Index of infectious agent */
                             const int susceptible_i,          /*!< Index of susceptible agent */
                             const PTDType& a_ptd,             /*!< Particle tile data */
-                            const DiseaseParm* const a_lparm, /*!< disease paramters */
+                            const DiseaseParm* const a_lparm, /*!< disease parameters */
                             const Real a_social_scale /*!< Social scale */) const noexcept {
         AMREX_ALWAYS_ASSERT(a_ptd.m_idata[IntIdx::school_id][infectious_i] == a_ptd.m_idata[IntIdx::school_id][susceptible_i]);
         AMREX_ALWAYS_ASSERT(a_ptd.m_idata[IntIdx::school_grade][infectious_i] ==

--- a/src/InteractionModSchool.H
+++ b/src/InteractionModSchool.H
@@ -172,13 +172,13 @@ void InteractionModSchool<PCType, PTDType, PType>::fastInteractSchool (PCType& a
                             auto community = getCommunityIndex(ptd, i);
                             int pos = (community * max_school_id + school_id_ptr[i]) * max_school_grade + school_grade_ptr[i];
                             if (getSchoolType(school_grade_ptr[i]) == SchoolType::daycare) {
-                                if (isAsymptomatic(i, ptd, d)) {
+                                if (isAsymptomatic(i, ptd, d) || isPresymptomatic(i, ptd, d)) {
                                     Gpu::Atomic::AddNoRet(&infected_daycare_asymp_d_ptr[pos], 1);
                                 } else {
                                     Gpu::Atomic::AddNoRet(&infected_daycare_d_ptr[pos], 1);
                                 }
                             } else {
-                                if (isAsymptomatic(i, ptd, d)) {
+                                if (isAsymptomatic(i, ptd, d) || isPresymptomatic(i, ptd, d)) {
                                     Gpu::Atomic::AddNoRet(&infected_school_asymp_d_ptr[pos], 1);
                                 } else {
                                     Gpu::Atomic::AddNoRet(&infected_school_d_ptr[pos], 1);

--- a/src/InteractionModSchool.H
+++ b/src/InteractionModSchool.H
@@ -201,8 +201,10 @@ void InteractionModSchool<PCType, PTDType, PType>::fastInteractSchool (PCType& a
                                     Real daycare_prob = 1.0_rt - infect * lparm->xmit_school[SchoolType::daycare] * scale;
                                     prob_ptr[i] *= static_cast<ParticleReal>(std::pow(daycare_prob, num_infected_daycare));
                                     int num_infected_daycare_asymp = infected_daycare_asymp_d_ptr[pos];
-                                    Real daycare_prob_asymp = 1.0_rt - lparm->asymp_relative_inf * infect * lparm->xmit_school[SchoolType::daycare] * scale;
-                                    prob_ptr[i] *= static_cast<ParticleReal>(std::pow(daycare_prob_asymp, num_infected_daycare_asymp));
+                                    Real daycare_prob_asymp = 1.0_rt - lparm->asymp_relative_inf * infect *
+                                                                               lparm->xmit_school[SchoolType::daycare] * scale;
+                                    prob_ptr[i] *=
+                                            static_cast<ParticleReal>(std::pow(daycare_prob_asymp, num_infected_daycare_asymp));
                                 }
                             } else {
                                 int num_infected_school = infected_school_d_ptr[pos];

--- a/src/InteractionModSchool.H
+++ b/src/InteractionModSchool.H
@@ -113,6 +113,8 @@ void InteractionModSchool<PCType, PTDType, PType>::fastInteractSchool (PCType& a
 
     Vector<Gpu::DeviceVector<int>> infected_school_d(OMP_MAX_THREADS);
     Vector<Gpu::DeviceVector<int>> infected_daycare_d(OMP_MAX_THREADS);
+    Vector<Gpu::DeviceVector<int>> infected_school_asymp_d(OMP_MAX_THREADS);
+    Vector<Gpu::DeviceVector<int>> infected_daycare_asymp_d(OMP_MAX_THREADS);
 
     for (int lev = 0; lev < agents.numLevels(); ++lev) {
 #ifdef AMREX_USE_OMP
@@ -138,8 +140,12 @@ void InteractionModSchool<PCType, PTDType, PType>::fastInteractSchool (PCType& a
 
             infected_school_d[OMP_THREAD_NUM].resize(max_communities * max_school_id * max_school_grade);
             infected_daycare_d[OMP_THREAD_NUM].resize(max_communities * max_school_id * max_school_grade);
+            infected_school_asymp_d[OMP_THREAD_NUM].resize(max_communities * max_school_id * max_school_grade);
+            infected_daycare_asymp_d[OMP_THREAD_NUM].resize(max_communities * max_school_id * max_school_grade);
             auto infected_school_d_ptr = infected_school_d[OMP_THREAD_NUM].data();
             auto infected_daycare_d_ptr = infected_daycare_d[OMP_THREAD_NUM].data();
+            auto infected_school_asymp_d_ptr = infected_school_asymp_d[OMP_THREAD_NUM].data();
+            auto infected_daycare_asymp_d_ptr = infected_daycare_asymp_d[OMP_THREAD_NUM].data();
 
             /*
             Print() << mfi.tilebox() << " np " << np << " max communities " << max_communities
@@ -152,6 +158,9 @@ void InteractionModSchool<PCType, PTDType, PType>::fastInteractSchool (PCType& a
                     devMemset(infected_school_d_ptr, 0, infected_school_d[OMP_THREAD_NUM].size() * sizeof(int));
                     devMemset(infected_daycare_d_ptr, 0, infected_daycare_d[OMP_THREAD_NUM].size() * sizeof(int));
 
+                    devMemset(infected_school_asymp_d_ptr, 0, infected_school_asymp_d[OMP_THREAD_NUM].size() * sizeof(int));
+                    devMemset(infected_daycare_asymp_d_ptr, 0, infected_daycare_asymp_d[OMP_THREAD_NUM].size() * sizeof(int));
+
                     auto prob_ptr = soa.GetRealData(RealIdx::nattribs + r0(d) + RealIdxDisease::prob).data();
                     auto lparm = agents.getDiseaseParameters_d(d);
                     auto lparm_h = agents.getDiseaseParameters_h(d);
@@ -163,9 +172,17 @@ void InteractionModSchool<PCType, PTDType, PType>::fastInteractSchool (PCType& a
                             auto community = getCommunityIndex(ptd, i);
                             int pos = (community * max_school_id + school_id_ptr[i]) * max_school_grade + school_grade_ptr[i];
                             if (getSchoolType(school_grade_ptr[i]) == SchoolType::daycare) {
-                                Gpu::Atomic::AddNoRet(&infected_daycare_d_ptr[pos], 1);
+                                if (isAsymptomatic(i, ptd, d)) {
+                                    Gpu::Atomic::AddNoRet(&infected_daycare_asymp_d_ptr[pos], 1);
+                                } else {
+                                    Gpu::Atomic::AddNoRet(&infected_daycare_d_ptr[pos], 1);
+                                }
                             } else {
-                                Gpu::Atomic::AddNoRet(&infected_school_d_ptr[pos], 1);
+                                if (isAsymptomatic(i, ptd, d)) {
+                                    Gpu::Atomic::AddNoRet(&infected_school_asymp_d_ptr[pos], 1);
+                                } else {
+                                    Gpu::Atomic::AddNoRet(&infected_school_d_ptr[pos], 1);
+                                }
                             }
                         }
                     });
@@ -183,9 +200,13 @@ void InteractionModSchool<PCType, PTDType, PType>::fastInteractSchool (PCType& a
                                     int num_infected_daycare = infected_daycare_d_ptr[pos];
                                     Real daycare_prob = 1.0_rt - infect * lparm->xmit_school[SchoolType::daycare] * scale;
                                     prob_ptr[i] *= static_cast<ParticleReal>(std::pow(daycare_prob, num_infected_daycare));
+                                    int num_infected_daycare_asymp = infected_daycare_asymp_d_ptr[pos];
+                                    Real daycare_prob_asymp = 1.0_rt - lparm->asymp_relative_inf * infect * lparm->xmit_school[SchoolType::daycare] * scale;
+                                    prob_ptr[i] *= static_cast<ParticleReal>(std::pow(daycare_prob_asymp, num_infected_daycare_asymp));
                                 }
                             } else {
                                 int num_infected_school = infected_school_d_ptr[pos];
+                                int num_infected_school_asymp = infected_school_asymp_d_ptr[pos];
                                 Real xmit = 0.0_rt;
                                 if (adults) {                                    // transmitters are adults
                                     if (age_group_ptr[i] <= AgeGroups::a5to17) { // Adult teacher/staff -> child student
@@ -204,6 +225,8 @@ void InteractionModSchool<PCType, PTDType, PType>::fastInteractSchool (PCType& a
                                 }
                                 Real school_prob = 1.0_rt - infect * xmit * scale;
                                 prob_ptr[i] *= static_cast<ParticleReal>(std::pow(school_prob, num_infected_school));
+                                Real school_prob_asymp = 1.0_rt - lparm->asymp_relative_inf * infect * xmit * scale;
+                                prob_ptr[i] *= static_cast<ParticleReal>(std::pow(school_prob_asymp, num_infected_school_asymp));
                             }
                         }
                     });

--- a/src/InteractionModWork.H
+++ b/src/InteractionModWork.H
@@ -138,7 +138,7 @@ void InteractionModWork<PCType, PTDType, PType>::fastInteractWork (PCType& agent
                     if (isInfectious(i, ptd, d) && isCandidate(i, ptd)) {
                         auto community = getCommunityIndex(ptd, i);
                         int wgroup_i = (community * max_workgroup + workgroup_ptr[i]) * max_naics + naics_ptr[i];
-                        if (isAsymptomatic(i, ptd, d)) {
+                        if (isAsymptomatic(i, ptd, d) || isPresymptomatic(i, ptd, d)) {
                             Gpu::Atomic::AddNoRet(&infected_workgroup_asymp_d_ptr[wgroup_i], 1);
                         } else {
                             Gpu::Atomic::AddNoRet(&infected_workgroup_d_ptr[wgroup_i], 1);

--- a/src/InteractionModWork.H
+++ b/src/InteractionModWork.H
@@ -90,6 +90,7 @@ void InteractionModWork<PCType, PTDType, PType>::fastInteractWork (PCType& agent
     WorkCandidate<PTDType> isCandidate;
 
     Vector<Gpu::DeviceVector<int>> infected_workgroup_d(OMP_MAX_THREADS);
+    Vector<Gpu::DeviceVector<int>> infected_workgroup_asymp_d(OMP_MAX_THREADS);
 
     for (int lev = 0; lev < agents.numLevels(); ++lev) {
 #ifdef AMREX_USE_OMP
@@ -116,12 +117,16 @@ void InteractionModWork<PCType, PTDType, PType>::fastInteractWork (PCType& agent
             infected_workgroup_d[OMP_THREAD_NUM].resize(max_communities * max_workgroup * max_naics);
             auto infected_workgroup_d_ptr = infected_workgroup_d[OMP_THREAD_NUM].data();
 
+            infected_workgroup_asymp_d[OMP_THREAD_NUM].resize(max_communities * max_workgroup * max_naics);
+            auto infected_workgroup_asymp_d_ptr = infected_workgroup_asymp_d[OMP_THREAD_NUM].data();
+
             // Print() << mfi.tilebox() << " np " << np << " max communities " << max_communities
             //         << " max workgroup " << max_workgroup << " max naics " << max_naics
             //         << " workgroup vector size " << max_communities * max_workgroup * max_naics
             //         << "\n";
             for (int d = 0; d < n_disease; d++) {
                 devMemset(infected_workgroup_d_ptr, 0, infected_workgroup_d[OMP_THREAD_NUM].size() * sizeof(int));
+                devMemset(infected_workgroup_asymp_d_ptr, 0, infected_workgroup_asymp_d[OMP_THREAD_NUM].size() * sizeof(int));
 
                 auto prob_ptr = soa.GetRealData(RealIdx::nattribs + r0(d) + RealIdxDisease::prob).data();
                 auto lparm = agents.getDiseaseParameters_d(d);
@@ -133,7 +138,11 @@ void InteractionModWork<PCType, PTDType, PType>::fastInteractWork (PCType& agent
                     if (isInfectious(i, ptd, d) && isCandidate(i, ptd)) {
                         auto community = getCommunityIndex(ptd, i);
                         int wgroup_i = (community * max_workgroup + workgroup_ptr[i]) * max_naics + naics_ptr[i];
-                        Gpu::Atomic::AddNoRet(&infected_workgroup_d_ptr[wgroup_i], 1);
+                        if (isAsymptomatic(i, ptd, d)) {
+                            Gpu::Atomic::AddNoRet(&infected_workgroup_asymp_d_ptr[wgroup_i], 1);
+                        } else {
+                            Gpu::Atomic::AddNoRet(&infected_workgroup_d_ptr[wgroup_i], 1);
+                        }
                     }
                 });
                 Gpu::synchronize();
@@ -145,6 +154,9 @@ void InteractionModWork<PCType, PTDType, PType>::fastInteractWork (PCType& agent
                         int num_infected_workgroup = infected_workgroup_d_ptr[wgroup_i];
                         Real workgroup_prob = 1.0_prt - infect * lparm->xmit_work * scale;
                         prob_ptr[i] *= static_cast<ParticleReal>(std::pow(workgroup_prob, num_infected_workgroup));
+                        int num_infected_workgroup_asymp = infected_workgroup_asymp_d_ptr[wgroup_i];
+                        Real workgroup_prob_asymp = 1.0_prt -  lparm->asymp_relative_inf * infect * lparm->xmit_work * scale;
+                        prob_ptr[i] *= static_cast<ParticleReal>(std::pow(workgroup_prob_asymp, num_infected_workgroup_asymp));
                     }
                 });
                 Gpu::synchronize();

--- a/src/InteractionModWork.H
+++ b/src/InteractionModWork.H
@@ -155,7 +155,7 @@ void InteractionModWork<PCType, PTDType, PType>::fastInteractWork (PCType& agent
                         Real workgroup_prob = 1.0_prt - infect * lparm->xmit_work * scale;
                         prob_ptr[i] *= static_cast<ParticleReal>(std::pow(workgroup_prob, num_infected_workgroup));
                         int num_infected_workgroup_asymp = infected_workgroup_asymp_d_ptr[wgroup_i];
-                        Real workgroup_prob_asymp = 1.0_prt -  lparm->asymp_relative_inf * infect * lparm->xmit_work * scale;
+                        Real workgroup_prob_asymp = 1.0_prt - lparm->asymp_relative_inf * infect * lparm->xmit_work * scale;
                         prob_ptr[i] *= static_cast<ParticleReal>(std::pow(workgroup_prob_asymp, num_infected_workgroup_asymp));
                     }
                 });

--- a/src/InteractionModWorkNborhood.H
+++ b/src/InteractionModWorkNborhood.H
@@ -147,7 +147,7 @@ void InteractionModWorkNborhood<PCType, PTDType, PType>::fastInteractWorkNborhoo
                         // always use work nborhood, because even age group 0 could be in another nborhood during the day for
                         // daycare
                         int nborhood = work_nborhood_ptr[i];
-                        if (isAsymptomatic(i, ptd, d)) {
+                        if (isAsymptomatic(i, ptd, d) || isPresymptomatic(i, ptd, d)) {
                             Gpu::Atomic::AddNoRet(&infected_community_asymp_d_ptr[community], 1);
                             Gpu::Atomic::AddNoRet(&infected_nborhood_asymp_d_ptr[community * max_nborhood + nborhood], 1);
                         } else {

--- a/src/InteractionModWorkNborhood.H
+++ b/src/InteractionModWorkNborhood.H
@@ -93,6 +93,8 @@ void InteractionModWorkNborhood<PCType, PTDType, PType>::fastInteractWorkNborhoo
     // each thread needs its own vector
     Vector<Gpu::DeviceVector<int>> infected_community_d(OMP_MAX_THREADS);
     Vector<Gpu::DeviceVector<int>> infected_nborhood_d(OMP_MAX_THREADS);
+    Vector<Gpu::DeviceVector<int>> infected_community_asymp_d(OMP_MAX_THREADS);
+    Vector<Gpu::DeviceVector<int>> infected_nborhood_asymp_d(OMP_MAX_THREADS);
 
     for (int lev = 0; lev < agents.numLevels(); ++lev) {
 #ifdef AMREX_USE_OMP
@@ -117,6 +119,11 @@ void InteractionModWorkNborhood<PCType, PTDType, PType>::fastInteractWorkNborhoo
             infected_nborhood_d[OMP_THREAD_NUM].resize(max_communities * max_nborhood);
             auto infected_community_d_ptr = infected_community_d[OMP_THREAD_NUM].data();
             auto infected_nborhood_d_ptr = infected_nborhood_d[OMP_THREAD_NUM].data();
+
+            infected_community_asymp_d[OMP_THREAD_NUM].resize(max_communities);
+            infected_nborhood_asymp_d[OMP_THREAD_NUM].resize(max_communities * max_nborhood);
+            auto infected_community_asymp_d_ptr = infected_community_asymp_d[OMP_THREAD_NUM].data();
+            auto infected_nborhood_asymp_d_ptr = infected_nborhood_asymp_d[OMP_THREAD_NUM].data();
             /*
             Print() << mfi.tilebox() << " np " << np << " max communities " << max_communities
                     << " max nborhood " << max_nborhood
@@ -126,6 +133,8 @@ void InteractionModWorkNborhood<PCType, PTDType, PType>::fastInteractWorkNborhoo
             for (int d = 0; d < n_disease; d++) {
                 devMemset(infected_community_d_ptr, 0, infected_community_d[OMP_THREAD_NUM].size() * sizeof(int));
                 devMemset(infected_nborhood_d_ptr, 0, infected_nborhood_d[OMP_THREAD_NUM].size() * sizeof(int));
+                devMemset(infected_community_asymp_d_ptr, 0, infected_community_asymp_d[OMP_THREAD_NUM].size() * sizeof(int));
+                devMemset(infected_nborhood_asymp_d_ptr, 0, infected_nborhood_asymp_d[OMP_THREAD_NUM].size() * sizeof(int));
                 auto prob_ptr = soa.GetRealData(RealIdx::nattribs + r0(d) + RealIdxDisease::prob).data();
                 auto lparm = agents.getDiseaseParameters_d(d);
                 auto lparm_h = agents.getDiseaseParameters_h(d);
@@ -138,8 +147,13 @@ void InteractionModWorkNborhood<PCType, PTDType, PType>::fastInteractWorkNborhoo
                         // always use work nborhood, because even age group 0 could be in another nborhood during the day for
                         // daycare
                         int nborhood = work_nborhood_ptr[i];
-                        Gpu::Atomic::AddNoRet(&infected_community_d_ptr[community], 1);
-                        Gpu::Atomic::AddNoRet(&infected_nborhood_d_ptr[community * max_nborhood + nborhood], 1);
+                        if (isAsymptomatic(i, ptd, d)) {
+                            Gpu::Atomic::AddNoRet(&infected_community_asymp_d_ptr[community], 1);
+                            Gpu::Atomic::AddNoRet(&infected_nborhood_asymp_d_ptr[community * max_nborhood + nborhood], 1);
+                        } else {
+                            Gpu::Atomic::AddNoRet(&infected_community_d_ptr[community], 1);
+                            Gpu::Atomic::AddNoRet(&infected_nborhood_d_ptr[community * max_nborhood + nborhood], 1);
+                        }
                     }
                 });
                 Gpu::synchronize();
@@ -150,12 +164,19 @@ void InteractionModWorkNborhood<PCType, PTDType, PType>::fastInteractWorkNborhoo
                         int nborhood = work_nborhood_ptr[i];
                         int num_infected_nborhood = infected_nborhood_d_ptr[community * max_nborhood + nborhood];
                         int num_infected_community = infected_community_d_ptr[community];
+                        int num_infected_nborhood_asymp = infected_nborhood_asymp_d_ptr[community * max_nborhood + nborhood];
+                        int num_infected_community_asymp = infected_community_asymp_d_ptr[community];
                         AMREX_ALWAYS_ASSERT(num_infected_community >= num_infected_nborhood);
                         Real comm_prob = 1.0_rt - infect * lparm->xmit_comm[ptd.m_idata[IntIdx::age_group][i]] * scale;
                         prob_ptr[i] *=
                                 static_cast<ParticleReal>(std::pow(comm_prob, num_infected_community - num_infected_nborhood));
                         Real nborhood_prob = 1.0_rt - infect * lparm->xmit_hood[ptd.m_idata[IntIdx::age_group][i]] * scale;
                         prob_ptr[i] *= static_cast<ParticleReal>(std::pow(nborhood_prob, num_infected_nborhood));
+                        Real comm_prob_asymp = 1.0_rt - lparm->asymp_relative_inf * infect * lparm->xmit_comm[ptd.m_idata[IntIdx::age_group][i]] * scale;
+                        prob_ptr[i] *=
+                                static_cast<ParticleReal>(std::pow(comm_prob_asymp, num_infected_community_asymp - num_infected_nborhood_asymp));
+                        Real nborhood_prob_asymp = 1.0_rt - lparm->asymp_relative_inf * infect * lparm->xmit_hood[ptd.m_idata[IntIdx::age_group][i]] * scale;
+                        prob_ptr[i] *= static_cast<ParticleReal>(std::pow(nborhood_prob_asymp, num_infected_nborhood_asymp));
                     }
                 });
                 Gpu::synchronize();

--- a/src/InteractionModWorkNborhood.H
+++ b/src/InteractionModWorkNborhood.H
@@ -172,10 +172,12 @@ void InteractionModWorkNborhood<PCType, PTDType, PType>::fastInteractWorkNborhoo
                                 static_cast<ParticleReal>(std::pow(comm_prob, num_infected_community - num_infected_nborhood));
                         Real nborhood_prob = 1.0_rt - infect * lparm->xmit_hood[ptd.m_idata[IntIdx::age_group][i]] * scale;
                         prob_ptr[i] *= static_cast<ParticleReal>(std::pow(nborhood_prob, num_infected_nborhood));
-                        Real comm_prob_asymp = 1.0_rt - lparm->asymp_relative_inf * infect * lparm->xmit_comm[ptd.m_idata[IntIdx::age_group][i]] * scale;
-                        prob_ptr[i] *=
-                                static_cast<ParticleReal>(std::pow(comm_prob_asymp, num_infected_community_asymp - num_infected_nborhood_asymp));
-                        Real nborhood_prob_asymp = 1.0_rt - lparm->asymp_relative_inf * infect * lparm->xmit_hood[ptd.m_idata[IntIdx::age_group][i]] * scale;
+                        Real comm_prob_asymp = 1.0_rt - lparm->asymp_relative_inf * infect *
+                                                                lparm->xmit_comm[ptd.m_idata[IntIdx::age_group][i]] * scale;
+                        prob_ptr[i] *= static_cast<ParticleReal>(
+                                std::pow(comm_prob_asymp, num_infected_community_asymp - num_infected_nborhood_asymp));
+                        Real nborhood_prob_asymp = 1.0_rt - lparm->asymp_relative_inf * infect *
+                                                                    lparm->xmit_hood[ptd.m_idata[IntIdx::age_group][i]] * scale;
                         prob_ptr[i] *= static_cast<ParticleReal>(std::pow(nborhood_prob_asymp, num_infected_nborhood_asymp));
                     }
                 });

--- a/src/InteractionModWorkNborhood.H
+++ b/src/InteractionModWorkNborhood.H
@@ -21,7 +21,7 @@ struct BinaryInteractionWorkNborhood {
     ParticleReal operator()(const int infectious_i,           /*!< Index of infectious agent */
                             const int susceptible_i,          /*!< Index of susceptible agent */
                             const PTDType& a_ptd,             /*!< Particle tile data */
-                            const DiseaseParm* const a_lparm, /*!< disease paramters */
+                            const DiseaseParm* const a_lparm, /*!< disease parameters */
                             const Real a_social_scale /*!< Social scale */) const noexcept {
         auto age_group_ptr = a_ptd.m_idata[IntIdx::age_group];
         auto nborhood_ptr = a_ptd.m_idata[IntIdx::nborhood];

--- a/src/InteractionModel.H
+++ b/src/InteractionModel.H
@@ -184,7 +184,7 @@ void interactAgentsImpl (IModel& interaction_model, AgentContainer& agents, int 
                 auto lparm_h = agents.getDiseaseParameters_h(d);
                 Real scale = 1.0_prt; // TODO this should vary based on cell
                 Real infect = (1.0_rt - lparm_h->vac_eff);
-		Real asymp_relative_inf = lparm_h->asymp_relative_inf;
+        Real asymp_relative_inf = lparm_h->asymp_relative_inf;
 
                 ParallelFor(bins_ptr->numItems(), [=] AMREX_GPU_DEVICE (int ii) noexcept {
                     auto infectious_i = inds[ii];
@@ -196,7 +196,7 @@ void interactAgentsImpl (IModel& interaction_model, AgentContainer& agents, int 
                     // because there are usually more susceptible agents than infectious. This can be a large performance
                     // difference for CPU only runs.
                     if (isInfectious(infectious_i, ptd, d) && isCandidate(infectious_i, ptd)) {
-			ParticleReal relative_inf = isAsymptomatic(infectious_i, ptd, d) ? asymp_relative_inf : 1.0_prt;
+            ParticleReal relative_inf = isAsymptomatic(infectious_i, ptd, d) ? asymp_relative_inf : 1.0_prt;
                         // Real i_mask = mask_arr(home_i_ptr[i], home_j_ptr[i], 0);
                         for (auto jj = cell_start; jj < cell_stop; ++jj) {
                             auto susceptible_i = inds[jj];

--- a/src/InteractionModel.H
+++ b/src/InteractionModel.H
@@ -196,7 +196,9 @@ void interactAgentsImpl (IModel& interaction_model, AgentContainer& agents, int 
                     // because there are usually more susceptible agents than infectious. This can be a large performance
                     // difference for CPU only runs.
                     if (isInfectious(infectious_i, ptd, d) && isCandidate(infectious_i, ptd)) {
-                        ParticleReal relative_inf = isAsymptomatic(infectious_i, ptd, d) || isPresymptomatic(i, ptd, d) ? asymp_relative_inf : 1.0_prt;
+                        ParticleReal relative_inf = isAsymptomatic(infectious_i, ptd, d) || isPresymptomatic(i, ptd, d)
+                                                            ? asymp_relative_inf
+                                                            : 1.0_prt;
                         // Real i_mask = mask_arr(home_i_ptr[i], home_j_ptr[i], 0);
                         for (auto jj = cell_start; jj < cell_stop; ++jj) {
                             auto susceptible_i = inds[jj];

--- a/src/InteractionModel.H
+++ b/src/InteractionModel.H
@@ -184,7 +184,7 @@ void interactAgentsImpl (IModel& interaction_model, AgentContainer& agents, int 
                 auto lparm_h = agents.getDiseaseParameters_h(d);
                 Real scale = 1.0_prt; // TODO this should vary based on cell
                 Real infect = (1.0_rt - lparm_h->vac_eff);
-        Real asymp_relative_inf = lparm_h->asymp_relative_inf;
+                Real asymp_relative_inf = lparm_h->asymp_relative_inf;
 
                 ParallelFor(bins_ptr->numItems(), [=] AMREX_GPU_DEVICE (int ii) noexcept {
                     auto infectious_i = inds[ii];
@@ -196,7 +196,7 @@ void interactAgentsImpl (IModel& interaction_model, AgentContainer& agents, int 
                     // because there are usually more susceptible agents than infectious. This can be a large performance
                     // difference for CPU only runs.
                     if (isInfectious(infectious_i, ptd, d) && isCandidate(infectious_i, ptd)) {
-            ParticleReal relative_inf = isAsymptomatic(infectious_i, ptd, d) ? asymp_relative_inf : 1.0_prt;
+                        ParticleReal relative_inf = isAsymptomatic(infectious_i, ptd, d) ? asymp_relative_inf : 1.0_prt;
                         // Real i_mask = mask_arr(home_i_ptr[i], home_j_ptr[i], 0);
                         for (auto jj = cell_start; jj < cell_stop; ++jj) {
                             auto susceptible_i = inds[jj];
@@ -204,7 +204,8 @@ void interactAgentsImpl (IModel& interaction_model, AgentContainer& agents, int 
                             if (infectious_i != susceptible_i && isSusceptible(susceptible_i, ptd, d) &&
                                 isCandidate(susceptible_i, ptd)) {
                                 ParticleReal prob =
-                                        1.0_prt - relative_inf * infect * binaryInteraction(infectious_i, susceptible_i, ptd, lparm, scale);
+                                        1.0_prt -
+                                        relative_inf * infect * binaryInteraction(infectious_i, susceptible_i, ptd, lparm, scale);
                                 // The atomic operation is needed because we find all the susceptible for each infectious in turn.
                                 // It can be eliminated by switching the order of infectious and susceptible.
                                 Gpu::Atomic::Multiply(&prob_ptr[susceptible_i], prob);

--- a/src/InteractionModel.H
+++ b/src/InteractionModel.H
@@ -196,7 +196,7 @@ void interactAgentsImpl (IModel& interaction_model, AgentContainer& agents, int 
                     // because there are usually more susceptible agents than infectious. This can be a large performance
                     // difference for CPU only runs.
                     if (isInfectious(infectious_i, ptd, d) && isCandidate(infectious_i, ptd)) {
-                        ParticleReal relative_inf = isAsymptomatic(infectious_i, ptd, d) ? asymp_relative_inf : 1.0_prt;
+                        ParticleReal relative_inf = isAsymptomatic(infectious_i, ptd, d) || isPresymptomatic(i, ptd, d) ? asymp_relative_inf : 1.0_prt;
                         // Real i_mask = mask_arr(home_i_ptr[i], home_j_ptr[i], 0);
                         for (auto jj = cell_start; jj < cell_stop; ++jj) {
                             auto susceptible_i = inds[jj];

--- a/src/InteractionModel.H
+++ b/src/InteractionModel.H
@@ -184,6 +184,7 @@ void interactAgentsImpl (IModel& interaction_model, AgentContainer& agents, int 
                 auto lparm_h = agents.getDiseaseParameters_h(d);
                 Real scale = 1.0_prt; // TODO this should vary based on cell
                 Real infect = (1.0_rt - lparm_h->vac_eff);
+		Real asymp_relative_inf = lparm_h->asymp_relative_inf;
 
                 ParallelFor(bins_ptr->numItems(), [=] AMREX_GPU_DEVICE (int ii) noexcept {
                     auto infectious_i = inds[ii];
@@ -195,6 +196,7 @@ void interactAgentsImpl (IModel& interaction_model, AgentContainer& agents, int 
                     // because there are usually more susceptible agents than infectious. This can be a large performance
                     // difference for CPU only runs.
                     if (isInfectious(infectious_i, ptd, d) && isCandidate(infectious_i, ptd)) {
+			ParticleReal relative_inf = isAsymptomatic(infectious_i, ptd, d) ? asymp_relative_inf : 1.0_prt;
                         // Real i_mask = mask_arr(home_i_ptr[i], home_j_ptr[i], 0);
                         for (auto jj = cell_start; jj < cell_stop; ++jj) {
                             auto susceptible_i = inds[jj];
@@ -202,7 +204,7 @@ void interactAgentsImpl (IModel& interaction_model, AgentContainer& agents, int 
                             if (infectious_i != susceptible_i && isSusceptible(susceptible_i, ptd, d) &&
                                 isCandidate(susceptible_i, ptd)) {
                                 ParticleReal prob =
-                                        1.0_prt - infect * binaryInteraction(infectious_i, susceptible_i, ptd, lparm, scale);
+                                        1.0_prt - relative_inf * infect * binaryInteraction(infectious_i, susceptible_i, ptd, lparm, scale);
                                 // The atomic operation is needed because we find all the susceptible for each infectious in turn.
                                 // It can be eliminated by switching the order of infectious and susceptible.
                                 Gpu::Atomic::Multiply(&prob_ptr[susceptible_i], prob);


### PR DESCRIPTION
This adds an option to reduce the infectiousness of asymptomatic agents. The following plot performs a sanity check on the model. The "dev" model should give (and in fact does give) the same results as this PR when the relative infectiousness is set to 1. 

<img width="640" height="480" alt="relative_inf" src="https://github.com/user-attachments/assets/f25a4589-803a-4e86-bc12-d2f1590b2202" />

Note - we may want to make this apply to presymptomatics as well as asymptomatics. 