### PR TITLE
Add capability to randomize length of stay in hospital

### DIFF
--- a/docs/source/usage/how_to_run.rst
+++ b/docs/source/usage/how_to_run.rst
@@ -165,8 +165,23 @@ The following inputs specify the disease parameters:
 * ``disease.hospital_delay_length_beta`` (`float`, default ``1.0``)
     Beta parameter for the hospital_delay length Gamma distribution. The hospital_delay length is the length of time in days after agents develop symptoms that they seek treatment.
     For a Gamma distribution, the mean is alpha*beta and the variance is alpha*beta^2.
+* ``disease.hospital_stay_type`` (`string`, either ``constant`` or ``random``, default ``constant``)
+    If ``constant``, all the agents in an age group will be in the hospital for a fixed number of days.
+    This number is set by the `disease.hospitalization_days` parameter.
+    If ``random``, the agents will draw a number of days from a Gamma distribution, with the parameters
+    of that distribution depending on age. These parameters are set by ``disease.hospitalization_days_alpha``
+    and ``disease.hospitalization_days_beta``.
 * ``disease.hospitalization_days`` (`list of float`, default ``3.0 8.0 7.0``)
     Number of hospitalization days for age groups: under 50, 50-64, 65 and over.
+    This parameter is only used if ``disease.hospital_stay_type`` is ``constant``.
+* ``disease.hospitalization_days_alpha`` (`list of float`, default ``1.33333333 0.5 0.57142857``)
+    Alpha parameter for gamma distribution for hospital stay length. The age groups
+    are: under 50, 50-64, 65 and over. For a Gamma distribution, the mean is alpha*beta and the variance is alpha*beta^2.
+    This parameter is only used if ``disease.hospital_stay_type`` is ``random``.
+* ``disease.hospitalization_days_beta`` (`list of float`, default ``1.5 4.0 3.5``)
+    Beta parameter for gamma distribution for hospital stay length. The age groups
+    are: under 50, 50-64, 65 and over. For a Gamma distribution, the mean is alpha*beta and the variance is alpha*beta^2.
+    This parameter is only used if ``disease.hospital_stay_type`` is ``random``.
 * ``disease.xmit_work`` (`float`, default ``0.0575``)
     Transmission probability within a workgroup.
 * ``disease.xmit_comm`` (`list of float`, default ``0.000018125 0.000054375 0.000145 0.000145 0.000145 0.0002175``)

--- a/src/DiseaseParm.H
+++ b/src/DiseaseParm.H
@@ -120,8 +120,8 @@ struct DiseaseParm {
 
     /*! Parameters for gamma distribution for hospital stay lengths. These are used if
      *  m_hospital_stay_type = HospitalStayType::Random */
-    Real m_t_hosp_alpha[AgeGroups_Hosp::total] = {1.33333333, 0.5, 0.57142857};
-    Real m_t_hosp_beta[AgeGroups_Hosp::total] = {1.5, 4.0, 3.5};
+    Real m_t_hosp_alpha[AgeGroups_Hosp::total] = {Real(1.33333333), Real(0.5), Real(0.57142857)};
+    Real m_t_hosp_beta[AgeGroups_Hosp::total] = {Real(1.5), Real(4.0), Real(3.5)};
 
     /*! sick -> hospital probabilities */
     Real m_CHR[AgeGroups::total] = {Real(.0104), Real(.0104), Real(.070), Real(.28), Real(.28), Real(1.0)};

--- a/src/DiseaseParm.H
+++ b/src/DiseaseParm.H
@@ -24,8 +24,8 @@ struct CaseTypes {
 
 struct HospitalStayType {
     enum {
-    Constant = 0, /*!< Agents in the same age group all have the same hospital stay duration. */
-    Random        /*!< Agents have a random hospital day duration, with the distribution varying by age group. */
+        Constant = 0, /*!< Agents in the same age group all have the same hospital stay duration. */
+        Random        /*!< Agents have a random hospital day duration, with the distribution varying by age group. */
     };
 };
 
@@ -168,19 +168,19 @@ struct DiseaseParm {
                 }
             } else { // Random
                 if (a_age_group == AgeGroups::o65) {
-                    int num_days = static_cast<int>(amrex::RandomGamma(m_t_hosp_alpha[AgeGroups_Hosp::o65],
-                                                                       m_t_hosp_beta[AgeGroups_Hosp::o65], a_reng));
-                    if (num_days < 0) { num_days = 0;}
+                    int num_days = static_cast<int>(
+                            amrex::RandomGamma(m_t_hosp_alpha[AgeGroups_Hosp::o65], m_t_hosp_beta[AgeGroups_Hosp::o65], a_reng));
+                    if (num_days < 0) { num_days = 0; }
                     *a_t_hosp = static_cast<ParticleReal>(num_days);
                 } else if (a_age_group == AgeGroups::a50to64) {
                     int num_days = static_cast<int>(amrex::RandomGamma(m_t_hosp_alpha[AgeGroups_Hosp::a50to64],
                                                                        m_t_hosp_beta[AgeGroups_Hosp::a50to64], a_reng));
-                    if (num_days < 0) { num_days = 0;}
+                    if (num_days < 0) { num_days = 0; }
                     *a_t_hosp = static_cast<ParticleReal>(num_days);
                 } else {
-                    int num_days = static_cast<int>(amrex::RandomGamma(m_t_hosp_alpha[AgeGroups_Hosp::u50],
-                                                                       m_t_hosp_beta[AgeGroups_Hosp::u50], a_reng));
-                    if (num_days < 0) { num_days = 0;}
+                    int num_days = static_cast<int>(
+                            amrex::RandomGamma(m_t_hosp_alpha[AgeGroups_Hosp::u50], m_t_hosp_beta[AgeGroups_Hosp::u50], a_reng));
+                    if (num_days < 0) { num_days = 0; }
                     *a_t_hosp = static_cast<ParticleReal>(num_days);
                 }
             }

--- a/src/DiseaseParm.H
+++ b/src/DiseaseParm.H
@@ -170,17 +170,17 @@ struct DiseaseParm {
                 if (a_age_group == AgeGroups::o65) {
                     int num_days = static_cast<int>(amrex::RandomGamma(m_t_hosp_alpha[AgeGroups_Hosp::o65],
                                                                        m_t_hosp_beta[AgeGroups_Hosp::o65], a_reng));
-                    if (num_days < 0) { num_days = 0;)
+                    if (num_days < 0) { num_days = 0;}
                     *a_t_hosp = static_cast<ParticleReal>(num_days);
                 } else if (a_age_group == AgeGroups::a50to64) {
                     int num_days = static_cast<int>(amrex::RandomGamma(m_t_hosp_alpha[AgeGroups_Hosp::a50to64],
                                                                        m_t_hosp_beta[AgeGroups_Hosp::a50to64], a_reng));
-                    if (num_days < 0) { num_days = 0;)
+                    if (num_days < 0) { num_days = 0;}
                     *a_t_hosp = static_cast<ParticleReal>(num_days);
                 } else {
                     int num_days = static_cast<int>(amrex::RandomGamma(m_t_hosp_alpha[AgeGroups_Hosp::u50],
                                                                        m_t_hosp_beta[AgeGroups_Hosp::u50], a_reng));
-                    if (num_days < 0) { num_days = 0;)
+                    if (num_days < 0) { num_days = 0;}
                     *a_t_hosp = static_cast<ParticleReal>(num_days);
                 }
             }

--- a/src/DiseaseParm.H
+++ b/src/DiseaseParm.H
@@ -22,6 +22,13 @@ struct CaseTypes {
     };
 };
 
+struct HospitalStayType {
+    enum {
+	Constant = 0, /*!< Agents in the same age group all have the same hospital stay duration. */
+	Random        /*!< Agents have a random hospital day duration, with the distribution varying by age group. */
+    };
+};
+
 /*! \brief Disease parameters
 
     Structure containing disease parameters.
@@ -96,14 +103,25 @@ struct DiseaseParm {
     Real hospital_delay_length_alpha = Real(1.0); /*! alpha parameter for gamma distribution*/
     Real hospital_delay_length_beta = Real(1.0);  /*! beta parameter for gamma distribution*/
 
+    int m_hospital_stay_type = HospitalStayType::Constant;
+
     /*! number of hospitalization days by age group (#AgeGroups_Hosp); note that the
      *  age groups here are under 50, 50-64, and over 65, and *not* the age groups
      *  used in other parts of the code (#AgeGroups) */
     Real m_t_hosp[AgeGroups_Hosp::total] = {Real(3), Real(8), Real(7)};
     /*! Offset to separate the timers for hospital, ICU, and ventilator;
-     * needs to be greater than the maximum of #DiseaseParm::m_t_hosp
-     * Set automatically when the hospital days are set. */
-    Real m_t_hosp_offset = 10;
+     * Needs to be greater than the maximum of #DiseaseParm::m_t_hosp
+     * This will automatically be enforced when the hospital days are set.
+     * If using random hospital stays, this should be set large enough that
+       in practice it will not be smaller than the longest stay for an agent.
+       The default will probably be fine for most cases.
+    */
+    Real m_t_hosp_offset = 10000.0;
+
+    /*! Parameters for gamma distribution for hospital stay lengths. These are used if
+     *  m_hospital_stay_type = HospitalStayType::Random */
+    Real m_t_hosp_alpha[AgeGroups_Hosp::total] = {1.33333333, 0.5, 0.57142857};
+    Real m_t_hosp_beta[AgeGroups_Hosp::total] = {1.5, 4.0, 3.5};
 
     /*! sick -> hospital probabilities */
     Real m_CHR[AgeGroups::total] = {Real(.0104), Real(.0104), Real(.070), Real(.28), Real(.28), Real(1.0)};
@@ -140,12 +158,31 @@ struct DiseaseParm {
         *a_ICU = 0;
         *a_ventilator = 0;
         if (amrex::Random(a_reng) < m_CHR[a_age_group]) {
-            if (a_age_group == AgeGroups::o65) {
-                *a_t_hosp = m_t_hosp[AgeGroups_Hosp::o65];
-            } else if (a_age_group == AgeGroups::a50to64) {
-                *a_t_hosp = m_t_hosp[AgeGroups_Hosp::a50to64];
-            } else {
-                *a_t_hosp = m_t_hosp[AgeGroups_Hosp::u50];
+            if (m_hospital_stay_type == HospitalStayType::Constant) {
+                if (a_age_group == AgeGroups::o65) {
+                    *a_t_hosp = m_t_hosp[AgeGroups_Hosp::o65];
+                } else if (a_age_group == AgeGroups::a50to64) {
+                    *a_t_hosp = m_t_hosp[AgeGroups_Hosp::a50to64];
+                } else {
+                    *a_t_hosp = m_t_hosp[AgeGroups_Hosp::u50];
+                }
+            } else { // Random
+                if (a_age_group == AgeGroups::o65) {
+                    int num_days = static_cast<int>(amrex::RandomGamma(m_t_hosp_alpha[AgeGroups_Hosp::o65],
+                                                                       m_t_hosp_beta[AgeGroups_Hosp::o65], a_reng));
+                    if (num_days < 0) { num_days = 0;)
+                    *a_t_hosp = static_cast<ParticleReal>(num_days);
+                } else if (a_age_group == AgeGroups::a50to64) {
+                    int num_days = static_cast<int>(amrex::RandomGamma(m_t_hosp_alpha[AgeGroups_Hosp::a50to64],
+                                                                       m_t_hosp_beta[AgeGroups_Hosp::a50to64], a_reng));
+                    if (num_days < 0) { num_days = 0;)
+                    *a_t_hosp = static_cast<ParticleReal>(num_days);
+                } else {
+                    int num_days = static_cast<int>(amrex::RandomGamma(m_t_hosp_alpha[AgeGroups_Hosp::u50],
+                                                                       m_t_hosp_beta[AgeGroups_Hosp::u50], a_reng));
+                    if (num_days < 0) { num_days = 0;)
+                    *a_t_hosp = static_cast<ParticleReal>(num_days);
+                }
             }
             if (amrex::Random(a_reng) < m_CIC[a_age_group]) {
                 *a_t_hosp += m_t_hosp_offset;     // move to ICU, adds 10 days (m_t_hosp_offset)

--- a/src/DiseaseParm.H
+++ b/src/DiseaseParm.H
@@ -24,8 +24,8 @@ struct CaseTypes {
 
 struct HospitalStayType {
     enum {
-	Constant = 0, /*!< Agents in the same age group all have the same hospital stay duration. */
-	Random        /*!< Agents have a random hospital day duration, with the distribution varying by age group. */
+    Constant = 0, /*!< Agents in the same age group all have the same hospital stay duration. */
+    Random        /*!< Agents have a random hospital day duration, with the distribution varying by age group. */
     };
 };
 

--- a/src/DiseaseParm.cpp
+++ b/src/DiseaseParm.cpp
@@ -88,10 +88,29 @@ void DiseaseParm::readInputs (const std::string& a_pp_str /*!< Parmparse string 
     pp.query("immune_length_alpha", immune_length_alpha);
     pp.query("immune_length_beta", immune_length_beta);
 
-    m_t_hosp_offset = 0;
-    queryArray(pp, "hospitalization_days", m_t_hosp, AgeGroups_Hosp::total);
-    for (int i = 0; i < AgeGroups_Hosp::total; i++) {
-        if (m_t_hosp[i] > m_t_hosp_offset) { m_t_hosp_offset = m_t_hosp[i] + 3; }
+    std::string hospital_stay_type = "constant";
+    pp.query("hospital_stay_type", hospital_stay_type);
+    pp.query("t_hosp_offset", m_t_hosp_offset);
+
+    if (hospital_stay_type == "constant") {
+	m_hospital_stay_type = HospitalStayType::Constant;
+    } else if (hospital_stay_type == "random") {
+	m_hospital_stay_type = HospitalStayType::Random;
+    } else {
+	amrex::Abort("Unrecognized hospital stay type!");
+    }
+
+    if (m_hospital_stay_type == HospitalStayType::Constant) {
+	queryArray(pp, "hospitalization_days", m_t_hosp, AgeGroups_Hosp::total);
+	for (int i = 0; i < AgeGroups_Hosp::total; i++) {
+	    if (m_t_hosp[i] > m_t_hosp_offset) { m_t_hosp_offset = m_t_hosp[i] + 3; }
+	}
+    }
+    else if (m_hospital_stay_type == HospitalStayType::Random) {
+	queryArray(pp, "hospitalization_days_alpha", m_t_hosp_alpha, AgeGroups_Hosp::total);
+	queryArray(pp, "hospitalization_days_beta", m_t_hosp_beta, AgeGroups_Hosp::total);
+    } else {
+	amrex::Abort("Unrecognized hospital stay type!");
     }
 
     queryArray(pp, "CHR", m_CHR, AgeGroups::total);

--- a/src/DiseaseParm.cpp
+++ b/src/DiseaseParm.cpp
@@ -93,24 +93,24 @@ void DiseaseParm::readInputs (const std::string& a_pp_str /*!< Parmparse string 
     pp.query("t_hosp_offset", m_t_hosp_offset);
 
     if (hospital_stay_type == "constant") {
-	m_hospital_stay_type = HospitalStayType::Constant;
+    m_hospital_stay_type = HospitalStayType::Constant;
     } else if (hospital_stay_type == "random") {
-	m_hospital_stay_type = HospitalStayType::Random;
+    m_hospital_stay_type = HospitalStayType::Random;
     } else {
-	amrex::Abort("Unrecognized hospital stay type!");
+    amrex::Abort("Unrecognized hospital stay type!");
     }
 
     if (m_hospital_stay_type == HospitalStayType::Constant) {
-	queryArray(pp, "hospitalization_days", m_t_hosp, AgeGroups_Hosp::total);
-	for (int i = 0; i < AgeGroups_Hosp::total; i++) {
-	    if (m_t_hosp[i] > m_t_hosp_offset) { m_t_hosp_offset = m_t_hosp[i] + 3; }
-	}
+    queryArray(pp, "hospitalization_days", m_t_hosp, AgeGroups_Hosp::total);
+    for (int i = 0; i < AgeGroups_Hosp::total; i++) {
+        if (m_t_hosp[i] > m_t_hosp_offset) { m_t_hosp_offset = m_t_hosp[i] + 3; }
+    }
     }
     else if (m_hospital_stay_type == HospitalStayType::Random) {
-	queryArray(pp, "hospitalization_days_alpha", m_t_hosp_alpha, AgeGroups_Hosp::total);
-	queryArray(pp, "hospitalization_days_beta", m_t_hosp_beta, AgeGroups_Hosp::total);
+    queryArray(pp, "hospitalization_days_alpha", m_t_hosp_alpha, AgeGroups_Hosp::total);
+    queryArray(pp, "hospitalization_days_beta", m_t_hosp_beta, AgeGroups_Hosp::total);
     } else {
-	amrex::Abort("Unrecognized hospital stay type!");
+    amrex::Abort("Unrecognized hospital stay type!");
     }
 
     queryArray(pp, "CHR", m_CHR, AgeGroups::total);

--- a/src/DiseaseParm.cpp
+++ b/src/DiseaseParm.cpp
@@ -93,24 +93,23 @@ void DiseaseParm::readInputs (const std::string& a_pp_str /*!< Parmparse string 
     pp.query("t_hosp_offset", m_t_hosp_offset);
 
     if (hospital_stay_type == "constant") {
-    m_hospital_stay_type = HospitalStayType::Constant;
+        m_hospital_stay_type = HospitalStayType::Constant;
     } else if (hospital_stay_type == "random") {
-    m_hospital_stay_type = HospitalStayType::Random;
+        m_hospital_stay_type = HospitalStayType::Random;
     } else {
-    amrex::Abort("Unrecognized hospital stay type!");
+        amrex::Abort("Unrecognized hospital stay type!");
     }
 
     if (m_hospital_stay_type == HospitalStayType::Constant) {
-    queryArray(pp, "hospitalization_days", m_t_hosp, AgeGroups_Hosp::total);
-    for (int i = 0; i < AgeGroups_Hosp::total; i++) {
-        if (m_t_hosp[i] > m_t_hosp_offset) { m_t_hosp_offset = m_t_hosp[i] + 3; }
-    }
-    }
-    else if (m_hospital_stay_type == HospitalStayType::Random) {
-    queryArray(pp, "hospitalization_days_alpha", m_t_hosp_alpha, AgeGroups_Hosp::total);
-    queryArray(pp, "hospitalization_days_beta", m_t_hosp_beta, AgeGroups_Hosp::total);
+        queryArray(pp, "hospitalization_days", m_t_hosp, AgeGroups_Hosp::total);
+        for (int i = 0; i < AgeGroups_Hosp::total; i++) {
+            if (m_t_hosp[i] > m_t_hosp_offset) { m_t_hosp_offset = m_t_hosp[i] + 3; }
+        }
+    } else if (m_hospital_stay_type == HospitalStayType::Random) {
+        queryArray(pp, "hospitalization_days_alpha", m_t_hosp_alpha, AgeGroups_Hosp::total);
+        queryArray(pp, "hospitalization_days_beta", m_t_hosp_beta, AgeGroups_Hosp::total);
     } else {
-    amrex::Abort("Unrecognized hospital stay type!");
+        amrex::Abort("Unrecognized hospital stay type!");
     }
 
     queryArray(pp, "CHR", m_CHR, AgeGroups::total);


### PR DESCRIPTION
This adds a new feature that lets you draw hospital stay durations from random gamma distributions, instead of having them fixed per age group.

The documentation has been updated to explain how to set the new parameters. Basically, you set `disease.hospital_stay_type = random` in the inputs file. The default distributions have been set to have the same mean as before, with a standard deviation of 2 days. You can also override the distribution using `disease.hospitalization_days_alpha` and `disease.hospitalization_days_beta`. 

I verified that the results look reasonable, and that they don't change at all if you use `disease.hospital_stay_type` = `constant`. 