### PR TITLE
Fixed randomized hospital stays

### DIFF
--- a/src/DiseaseParm.H
+++ b/src/DiseaseParm.H
@@ -117,7 +117,7 @@ struct DiseaseParm {
      * or whatvere value is generated from the gamma distribution for random length stays.
      * The default here is greater than a human lifespan, and so never needs to be changed.
      */
-    const Real m_t_hosp_offset = 100000.0;
+    Real m_t_hosp_offset = 100000.0;
 
     /*! Parameters for gamma distribution for hospital stay lengths. These are used if
      *  m_hospital_stay_type = HospitalStayType::Random */

--- a/src/DiseaseParm.H
+++ b/src/DiseaseParm.H
@@ -170,7 +170,7 @@ struct DiseaseParm {
                 int num_days = static_cast<int>(amrex::RandomGamma(m_t_hosp_alpha[age_idx], m_t_hosp_beta[age_idx], a_reng));
                 // the number of days must always be less than the offset, because the offset is used to determine when
                 // treatment is completed for ICU and ventilated. See HospitalModel::treatAgents
-                if (num_days > m_t_hosp_offset - 1) { num_days = m_t_hosp_offset - 1; }
+                if (num_days > m_t_hosp_offset - 1.0) { num_days = m_t_hosp_offset - 1.0; }
                 if (num_days < 1) { num_days = 1; }
                 *a_t_hosp = static_cast<ParticleReal>(num_days);
             }

--- a/src/DiseaseParm.H
+++ b/src/DiseaseParm.H
@@ -110,13 +110,14 @@ struct DiseaseParm {
      *  used in other parts of the code (#AgeGroups) */
     Real m_t_hosp[AgeGroups_Hosp::total] = {Real(3), Real(8), Real(7)};
     /*! Offset to separate the timers for hospital, ICU, and ventilator;
-     * Needs to be greater than the maximum of #DiseaseParm::m_t_hosp
-     * This will automatically be enforced when the hospital days are set.
-     * If using random hospital stays, this should be set large enough that
-       in practice it will not be smaller than the longest stay for an agent.
-       The default will probably be fine for most cases.
-    */
-    Real m_t_hosp_offset = 10.0;
+     * All agents just in hospital will have a timer counting up from 0, all agents in ICU will
+     * have a timer counting up from m_t_hosp_offset, and all agents ventilated will have a timer
+     * counting up from 2 * m_t_hosp_offset
+     * For this reason, this value needs to be greater than the maximum of #DiseaseParm::m_t_hosp,
+     * or whatvere value is generated from the gamma distribution for random length stays.
+     * The default here is greater than a human lifespan, and so never needs to be changed.
+     */
+    const Real m_t_hosp_offset = 100000.0;
 
     /*! Parameters for gamma distribution for hospital stay lengths. These are used if
      *  m_hospital_stay_type = HospitalStayType::Random */
@@ -168,17 +169,17 @@ struct DiseaseParm {
                 *a_t_hosp = m_t_hosp[age_idx];
             } else { // Random
                 int num_days = static_cast<int>(amrex::RandomGamma(m_t_hosp_alpha[age_idx], m_t_hosp_beta[age_idx], a_reng));
-                // the number of days must always be less than the offset, because the offset is used to determine when
-                // treatment is completed for ICU and ventilated. See HospitalModel::treatAgents
+                // the number of days must always be less than the offset, because the offset is used to separate out the
+                // only-hospitalized from ICU and ventilated
                 if (num_days > m_t_hosp_offset - 1.0) { num_days = (int)(m_t_hosp_offset - 1.0); }
                 if (num_days < 1) { num_days = 1; }
                 *a_t_hosp = static_cast<ParticleReal>(num_days);
             }
             if (amrex::Random(a_reng) < m_CIC[a_age_group]) {
-                *a_t_hosp += m_t_hosp_offset;     // move to ICU, adds a fixed number of days (m_t_hosp_offset)
+                *a_t_hosp += m_t_hosp_offset;     // move to ICU, treatment timer now runs starting at m_t_hosp_offset
                 *a_ICU = 1;
                 if (amrex::Random(a_reng) < m_CVE[a_age_group]) {
-                    *a_t_hosp += m_t_hosp_offset; // put on ventilator, adds another fixed number of days
+                    *a_t_hosp += m_t_hosp_offset; // put on ventilator, treatment timer now runs starting at 2 * m_t_hosp_offset
                     *a_ventilator = 1;
                 }
             }

--- a/src/DiseaseParm.H
+++ b/src/DiseaseParm.H
@@ -170,7 +170,7 @@ struct DiseaseParm {
                 int num_days = static_cast<int>(amrex::RandomGamma(m_t_hosp_alpha[age_idx], m_t_hosp_beta[age_idx], a_reng));
                 // the number of days must always be less than the offset, because the offset is used to determine when
                 // treatment is completed for ICU and ventilated. See HospitalModel::treatAgents
-                if (num_days > m_t_hosp_offset - 1.0) { num_days = m_t_hosp_offset - 1.0; }
+                if (num_days > m_t_hosp_offset - 1.0) { num_days = (int)(m_t_hosp_offset - 1.0); }
                 if (num_days < 1) { num_days = 1; }
                 *a_t_hosp = static_cast<ParticleReal>(num_days);
             }

--- a/src/DiseaseParm.H
+++ b/src/DiseaseParm.H
@@ -168,7 +168,9 @@ struct DiseaseParm {
                 *a_t_hosp = m_t_hosp[age_idx];
             } else { // Random
                 int num_days = static_cast<int>(amrex::RandomGamma(m_t_hosp_alpha[age_idx], m_t_hosp_beta[age_idx], a_reng));
-                if (num_days > m_t_hosp_offset - 3) { num_days = m_t_hosp_offset - 3; }
+                // the number of days must always be less than the offset, because the offset is used to determine when
+                // treatment is completed for ICU and ventilated. See HospitalModel::treatAgents
+                if (num_days > m_t_hosp_offset - 1) { num_days = m_t_hosp_offset - 1; }
                 if (num_days < 1) { num_days = 1; }
                 *a_t_hosp = static_cast<ParticleReal>(num_days);
             }

--- a/src/DiseaseParm.H
+++ b/src/DiseaseParm.H
@@ -168,6 +168,7 @@ struct DiseaseParm {
                 *a_t_hosp = m_t_hosp[age_idx];
             } else { // Random
                 int num_days = static_cast<int>(amrex::RandomGamma(m_t_hosp_alpha[age_idx], m_t_hosp_beta[age_idx], a_reng));
+                if (num_days > m_t_hosp_offset - 3) { num_days = m_t_hosp_offset - 3; }
                 if (num_days < 1) { num_days = 1; }
                 *a_t_hosp = static_cast<ParticleReal>(num_days);
             }

--- a/src/DiseaseParm.H
+++ b/src/DiseaseParm.H
@@ -116,7 +116,7 @@ struct DiseaseParm {
        in practice it will not be smaller than the longest stay for an agent.
        The default will probably be fine for most cases.
     */
-    Real m_t_hosp_offset = 10000.0;
+    Real m_t_hosp_offset = 10.0;
 
     /*! Parameters for gamma distribution for hospital stay lengths. These are used if
      *  m_hospital_stay_type = HospitalStayType::Random */
@@ -158,37 +158,24 @@ struct DiseaseParm {
         *a_ICU = 0;
         *a_ventilator = 0;
         if (amrex::Random(a_reng) < m_CHR[a_age_group]) {
+            int age_idx = AgeGroups_Hosp::u50;
+            if (a_age_group == AgeGroups::o65) {
+                age_idx = AgeGroups_Hosp::o65;
+            } else if (a_age_group == AgeGroups::a50to64) {
+                age_idx = AgeGroups_Hosp::a50to64;
+            }
             if (m_hospital_stay_type == HospitalStayType::Constant) {
-                if (a_age_group == AgeGroups::o65) {
-                    *a_t_hosp = m_t_hosp[AgeGroups_Hosp::o65];
-                } else if (a_age_group == AgeGroups::a50to64) {
-                    *a_t_hosp = m_t_hosp[AgeGroups_Hosp::a50to64];
-                } else {
-                    *a_t_hosp = m_t_hosp[AgeGroups_Hosp::u50];
-                }
+                *a_t_hosp = m_t_hosp[age_idx];
             } else { // Random
-                if (a_age_group == AgeGroups::o65) {
-                    int num_days = static_cast<int>(
-                            amrex::RandomGamma(m_t_hosp_alpha[AgeGroups_Hosp::o65], m_t_hosp_beta[AgeGroups_Hosp::o65], a_reng));
-                    if (num_days < 0) { num_days = 0; }
-                    *a_t_hosp = static_cast<ParticleReal>(num_days);
-                } else if (a_age_group == AgeGroups::a50to64) {
-                    int num_days = static_cast<int>(amrex::RandomGamma(m_t_hosp_alpha[AgeGroups_Hosp::a50to64],
-                                                                       m_t_hosp_beta[AgeGroups_Hosp::a50to64], a_reng));
-                    if (num_days < 0) { num_days = 0; }
-                    *a_t_hosp = static_cast<ParticleReal>(num_days);
-                } else {
-                    int num_days = static_cast<int>(
-                            amrex::RandomGamma(m_t_hosp_alpha[AgeGroups_Hosp::u50], m_t_hosp_beta[AgeGroups_Hosp::u50], a_reng));
-                    if (num_days < 0) { num_days = 0; }
-                    *a_t_hosp = static_cast<ParticleReal>(num_days);
-                }
+                int num_days = static_cast<int>(amrex::RandomGamma(m_t_hosp_alpha[age_idx], m_t_hosp_beta[age_idx], a_reng));
+                if (num_days < 1) { num_days = 1; }
+                *a_t_hosp = static_cast<ParticleReal>(num_days);
             }
             if (amrex::Random(a_reng) < m_CIC[a_age_group]) {
-                *a_t_hosp += m_t_hosp_offset;     // move to ICU, adds 10 days (m_t_hosp_offset)
+                *a_t_hosp += m_t_hosp_offset;     // move to ICU, adds a fixed number of days (m_t_hosp_offset)
                 *a_ICU = 1;
                 if (amrex::Random(a_reng) < m_CVE[a_age_group]) {
-                    *a_t_hosp += m_t_hosp_offset; // put on ventilator, adds another 10 days
+                    *a_t_hosp += m_t_hosp_offset; // put on ventilator, adds another fixed number of days
                     *a_ventilator = 1;
                 }
             }

--- a/src/DiseaseParm.cpp
+++ b/src/DiseaseParm.cpp
@@ -90,7 +90,6 @@ void DiseaseParm::readInputs (const std::string& a_pp_str /*!< Parmparse string 
 
     std::string hospital_stay_type = m_hospital_stay_type == HospitalStayType::Constant ? "constant" : "random";
     pp.query("hospital_stay_type", hospital_stay_type);
-    pp.query("hospital_offset", m_t_hosp_offset);
 
     if (hospital_stay_type == "constant") {
         m_hospital_stay_type = HospitalStayType::Constant;
@@ -103,7 +102,7 @@ void DiseaseParm::readInputs (const std::string& a_pp_str /*!< Parmparse string 
     if (m_hospital_stay_type == HospitalStayType::Constant) {
         queryArray(pp, "hospitalization_days", m_t_hosp, AgeGroups_Hosp::total);
         for (int i = 0; i < AgeGroups_Hosp::total; i++) {
-            if (m_t_hosp[i] > m_t_hosp_offset) { m_t_hosp_offset = m_t_hosp[i] + 3; }
+            AMREX_ALWAYS_ASSERT(m_t_hosp[i] < m_t_hosp_offset);
         }
     } else if (m_hospital_stay_type == HospitalStayType::Random) {
         queryArray(pp, "hospitalization_days_alpha", m_t_hosp_alpha, AgeGroups_Hosp::total);

--- a/src/DiseaseParm.cpp
+++ b/src/DiseaseParm.cpp
@@ -88,9 +88,9 @@ void DiseaseParm::readInputs (const std::string& a_pp_str /*!< Parmparse string 
     pp.query("immune_length_alpha", immune_length_alpha);
     pp.query("immune_length_beta", immune_length_beta);
 
-    std::string hospital_stay_type = "constant";
+    std::string hospital_stay_type = m_hospital_stay_type == HospitalStayType::Constant ? "constant" : "random";
     pp.query("hospital_stay_type", hospital_stay_type);
-    pp.query("t_hosp_offset", m_t_hosp_offset);
+    pp.query("hospital_offset", m_t_hosp_offset);
 
     if (hospital_stay_type == "constant") {
         m_hospital_stay_type = HospitalStayType::Constant;

--- a/src/HospitalModel.H
+++ b/src/HospitalModel.H
@@ -144,10 +144,10 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                         // finished hospitalization period
                         flag_status_ptr[i] = DiseaseStats::hospitalization + 1;
                     } else if (timer_ptrs[d][i] == disease_parm_d->m_t_hosp_offset) {
-                        // finished ICU hospitalization period
+                        // finished ICU hospitalization period, counted down to m_t_hosp_offset
                         flag_status_ptr[i] = DiseaseStats::ICU + 1;
                     } else if (timer_ptrs[d][i] == 2 * disease_parm_d->m_t_hosp_offset) {
-                        // finished ventilator hospitalization period
+                        // finished ventilator hospitalization period, counted down to 2 * m_t_hosp_offset
                         flag_status_ptr[i] = DiseaseStats::ventilator + 1;
                     }
                     if (flag_status_ptr[i] > 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -459,11 +459,13 @@ void runAgent () {
 
                     File << std::setw(5) << i;
                     for (int j = 0; j < OutputStatus::ICU; ++j) {
+                        AMREX_ALWAYS_ASSERT(counts[j] >= 0);
                         File << std::setw(12) << counts[j];
                     }
                     File << std::setw(12) << mmc[1];
                     File << std::setw(12) << mmc[2];
                     for (int j = OutputStatus::R; j < OutputStatus::nattribs; ++j) {
+                        AMREX_ALWAYS_ASSERT(counts[j] >= 0);
                         File << std::setw(12) << counts[j];
                     }
                     // File << std::setw(12) << mmc[4];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -462,6 +462,9 @@ void runAgent () {
                         AMREX_ALWAYS_ASSERT(counts[j] >= 0);
                         File << std::setw(12) << counts[j];
                     }
+
+                    AMREX_ALWAYS_ASSERT(mmc[1] >= 0);
+                    AMREX_ALWAYS_ASSERT(mmc[2] >= 0);
                     File << std::setw(12) << mmc[1];
                     File << std::setw(12) << mmc[2];
                     for (int j = OutputStatus::R; j < OutputStatus::nattribs; ++j) {


### PR DESCRIPTION
Setting `disease.hospital_stay_type` did not actually set the type, which always defaulted to "constant". This PR fixes that and also simplifies the `checkHospitalization` implementation. 