### PR TITLE
Fix age group assignment for census data

### DIFF
--- a/src/AgentDefinitions.H
+++ b/src/AgentDefinitions.H
@@ -307,6 +307,8 @@ void setAgentData (PTDType& ptd, int ip, int i, int j,
                    const amrex::GpuArray<amrex::Real, 2>& dx, amrex::Long id, int cpu,
                    int age_group, int family, int nborhood, int n_disease)
 {
+    using namespace amrex::literals;
+
     ptd[ip].pos(0) = static_cast<amrex::ParticleReal>((i + 0.5_rt) * dx[0]);
     ptd[ip].pos(1) = static_cast<amrex::ParticleReal>((j + 0.5_rt) * dx[1]);
     ptd[ip].id() = id;

--- a/src/AgentDefinitions.H
+++ b/src/AgentDefinitions.H
@@ -301,6 +301,41 @@ bool isNewlyHospitalized (const int a_idx,      /*!< Agent index */
     }
 }
 
+template <typename PTDType>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void setAgentData (PTDType& ptd, int ip, int i, int j,
+                   const amrex::GpuArray<amrex::Real, 2>& dx, amrex::Long id, int cpu,
+                   int age_group, int family, int nborhood, int n_disease)
+{
+    ptd[ip].pos(0) = static_cast<amrex::ParticleReal>((i + 0.5_rt) * dx[0]);
+    ptd[ip].pos(1) = static_cast<amrex::ParticleReal>((j + 0.5_rt) * dx[1]);
+    ptd[ip].id() = id;
+    ptd[ip].cpu() = cpu;
+
+    for (int d = 0; d < n_disease; d++) {
+        ptd.m_runtime_idata[i0(d) + IntIdxDisease::status][ip] = 0;
+        ptd.m_runtime_rdata[r0(d) + RealIdxDisease::disease_counter][ip] = 0.0_prt;
+        ptd.m_runtime_rdata[r0(d) + RealIdxDisease::treatment_timer][ip] = 0.0_prt;
+    }
+
+    ptd.m_idata[IntIdx::age_group][ip] = age_group;
+    ptd.m_idata[IntIdx::family][ip] = family;
+    ptd.m_idata[IntIdx::home_i][ip] = i;
+    ptd.m_idata[IntIdx::home_j][ip] = j;
+    ptd.m_idata[IntIdx::work_i][ip] = i;
+    ptd.m_idata[IntIdx::work_j][ip] = j;
+    ptd.m_idata[IntIdx::trav_i][ip] = i;
+    ptd.m_idata[IntIdx::trav_j][ip] = j;
+    ptd.m_idata[IntIdx::hosp_i][ip] = -1;
+    ptd.m_idata[IntIdx::hosp_j][ip] = -1;
+    ptd.m_idata[IntIdx::nborhood][ip] = nborhood;
+    ptd.m_idata[IntIdx::work_nborhood][ip] = nborhood;
+    ptd.m_idata[IntIdx::workgroup][ip] = 0;
+    ptd.m_idata[IntIdx::naics][ip] = 0;
+    ptd.m_idata[IntIdx::random_travel][ip] = -1;
+    ptd.m_idata[IntIdx::air_travel][ip] = -1;
+}
+
 /*! \brief Is agent an adult? */
 template <typename PTDType>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE

--- a/src/AgentDefinitions.H
+++ b/src/AgentDefinitions.H
@@ -303,10 +303,8 @@ bool isNewlyHospitalized (const int a_idx,      /*!< Agent index */
 
 template <typename PTDType>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void setAgentData (PTDType& ptd, int ip, int i, int j,
-                   const amrex::GpuArray<amrex::Real, 2>& dx, amrex::Long id, int cpu,
-                   int age_group, int family, int nborhood, int n_disease)
-{
+void setAgentData (PTDType& ptd, int ip, int i, int j, const amrex::GpuArray<amrex::Real, 2>& dx, amrex::Long id, int cpu,
+                   int age_group, int family, int nborhood, int n_disease) {
     using namespace amrex::literals;
 
     ptd[ip].pos(0) = static_cast<amrex::ParticleReal>((i + 0.5_rt) * dx[0]);

--- a/src/CensusData.H
+++ b/src/CensusData.H
@@ -45,29 +45,25 @@ struct CensusData {
     void assignTeachersAndWorkgroup(AgentContainer& pc, const int workgroup_size);
 };
 
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    void assignSchool (int* school_grade, int* school_id, const int age_group, const int nborhood, const RandomEngine& engine);
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void assignSchool(int* school_grade, int* school_id, const int age_group, const int nborhood, const RandomEngine& engine);
 
-    template <typename PTDType>
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    void setAgentDataAndAssignSchool (PTDType& ptd, int ip, int i, int j, int k,
-                      const amrex::GpuArray<amrex::Real, 2>& dx, amrex::Long id, int cpu,
-                      int age_group, int family, int nborhood, int n_disease,
-                      amrex::Array4<int> const& nr_arr,
-                      amrex::Array4<int> const& student_counts_arr,
-                      const amrex::RandomEngine& engine)
-{
+template <typename PTDType>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void setAgentDataAndAssignSchool (PTDType& ptd, int ip, int i, int j, int k, const amrex::GpuArray<amrex::Real, 2>& dx,
+                                  amrex::Long id, int cpu, int age_group, int family, int nborhood, int n_disease,
+                                  amrex::Array4<int> const& nr_arr, amrex::Array4<int> const& student_counts_arr,
+                                  const amrex::RandomEngine& engine) {
     setAgentData(ptd, ip, i, j, dx, id, cpu, age_group, family, nborhood, n_disease);
     Gpu::Atomic::AddNoRet(&nr_arr(i, j, k, age_group), 1);
 
-    assignSchool(&ptd.m_idata[IntIdx::school_grade][ip],
-         &ptd.m_idata[IntIdx::school_id][ip], age_group, nborhood, engine);
+    assignSchool(&ptd.m_idata[IntIdx::school_grade][ip], &ptd.m_idata[IntIdx::school_id][ip], age_group, nborhood, engine);
     ptd.m_idata[IntIdx::school_closed][ip] = 0;
 
     // Increment the appropriate student counter based on the school assignment
     if (ptd.m_idata[IntIdx::school_id][ip] >= SchoolCensusIDType::daycare_5) {
-    Gpu::Atomic::AddNoRet(&student_counts_arr(i, j, k, SchoolCensusIDType::daycare_5 - 1), 1);
+        Gpu::Atomic::AddNoRet(&student_counts_arr(i, j, k, SchoolCensusIDType::daycare_5 - 1), 1);
     } else if (ptd.m_idata[IntIdx::school_id][ip] > SchoolCensusIDType::none) {
-    Gpu::Atomic::AddNoRet(&student_counts_arr(i, j, k, ptd.m_idata[IntIdx::school_id][ip] - 1), 1);
+        Gpu::Atomic::AddNoRet(&student_counts_arr(i, j, k, ptd.m_idata[IntIdx::school_id][ip] - 1), 1);
     }
 }

--- a/src/CensusData.H
+++ b/src/CensusData.H
@@ -51,23 +51,23 @@ struct CensusData {
     template <typename PTDType>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void setAgentDataAndAssignSchool (PTDType& ptd, int ip, int i, int j, int k,
-				      const amrex::GpuArray<amrex::Real, 2>& dx, amrex::Long id, int cpu,
-				      int age_group, int family, int nborhood, int n_disease,
-				      amrex::Array4<int> const& nr_arr,
-				      amrex::Array4<int> const& student_counts_arr,
-				      const amrex::RandomEngine& engine)
+                      const amrex::GpuArray<amrex::Real, 2>& dx, amrex::Long id, int cpu,
+                      int age_group, int family, int nborhood, int n_disease,
+                      amrex::Array4<int> const& nr_arr,
+                      amrex::Array4<int> const& student_counts_arr,
+                      const amrex::RandomEngine& engine)
 {
     setAgentData(ptd, ip, i, j, dx, id, cpu, age_group, family, nborhood, n_disease);
     Gpu::Atomic::AddNoRet(&nr_arr(i, j, k, age_group), 1);
 
     assignSchool(&ptd.m_idata[IntIdx::school_grade][ip],
-		 &ptd.m_idata[IntIdx::school_id][ip], age_group, nborhood, engine);
+         &ptd.m_idata[IntIdx::school_id][ip], age_group, nborhood, engine);
     ptd.m_idata[IntIdx::school_closed][ip] = 0;
 
     // Increment the appropriate student counter based on the school assignment
     if (ptd.m_idata[IntIdx::school_id][ip] >= SchoolCensusIDType::daycare_5) {
-	Gpu::Atomic::AddNoRet(&student_counts_arr(i, j, k, SchoolCensusIDType::daycare_5 - 1), 1);
+    Gpu::Atomic::AddNoRet(&student_counts_arr(i, j, k, SchoolCensusIDType::daycare_5 - 1), 1);
     } else if (ptd.m_idata[IntIdx::school_id][ip] > SchoolCensusIDType::none) {
-	Gpu::Atomic::AddNoRet(&student_counts_arr(i, j, k, ptd.m_idata[IntIdx::school_id][ip] - 1), 1);
+    Gpu::Atomic::AddNoRet(&student_counts_arr(i, j, k, ptd.m_idata[IntIdx::school_id][ip] - 1), 1);
     }
 }

--- a/src/CensusData.H
+++ b/src/CensusData.H
@@ -44,3 +44,30 @@ struct CensusData {
     // private:
     void assignTeachersAndWorkgroup(AgentContainer& pc, const int workgroup_size);
 };
+
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    void assignSchool (int* school_grade, int* school_id, const int age_group, const int nborhood, const RandomEngine& engine);
+
+    template <typename PTDType>
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    void setAgentDataAndAssignSchool (PTDType& ptd, int ip, int i, int j, int k,
+				      const amrex::GpuArray<amrex::Real, 2>& dx, amrex::Long id, int cpu,
+				      int age_group, int family, int nborhood, int n_disease,
+				      amrex::Array4<int> const& nr_arr,
+				      amrex::Array4<int> const& student_counts_arr,
+				      const amrex::RandomEngine& engine)
+{
+    setAgentData(ptd, ip, i, j, dx, id, cpu, age_group, family, nborhood, n_disease);
+    Gpu::Atomic::AddNoRet(&nr_arr(i, j, k, age_group), 1);
+
+    assignSchool(&ptd.m_idata[IntIdx::school_grade][ip],
+		 &ptd.m_idata[IntIdx::school_id][ip], age_group, nborhood, engine);
+    ptd.m_idata[IntIdx::school_closed][ip] = 0;
+
+    // Increment the appropriate student counter based on the school assignment
+    if (ptd.m_idata[IntIdx::school_id][ip] >= SchoolCensusIDType::daycare_5) {
+	Gpu::Atomic::AddNoRet(&student_counts_arr(i, j, k, SchoolCensusIDType::daycare_5 - 1), 1);
+    } else if (ptd.m_idata[IntIdx::school_id][ip] > SchoolCensusIDType::none) {
+	Gpu::Atomic::AddNoRet(&student_counts_arr(i, j, k, ptd.m_idata[IntIdx::school_id][ip] - 1), 1);
+    }
+}

--- a/src/CensusData.cpp
+++ b/src/CensusData.cpp
@@ -248,10 +248,10 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
         auto student_counts_arr = pc.m_student_counts[mfi].array();
         auto& agents_tile = pc.DefineAndReturnParticleTile(0, mfi);
         agents_tile.resize(nagents);
-    auto ptd = agents_tile.getParticleTileData();
+        auto ptd = agents_tile.getParticleTileData();
         auto dx = pc.ParticleGeom(0).CellSizeArray();
         auto my_proc = ParallelDescriptor::MyProc();
-    int n_disease = pc.m_num_diseases;
+        int n_disease = pc.m_num_diseases;
 
         Long pid;
 #ifdef AMREX_USE_OMP
@@ -293,7 +293,7 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
             int nborhood = 0;
             for (int ifam = 0; ifam < nf; ++ifam) {
                 int family = family_id_start + ifam;
-                int ii = family_size*ifam;
+                int ii = family_size * ifam;
                 int ip = start + ii;
 
                 int il2 = Random_int(100, engine);
@@ -310,7 +310,8 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
                     } else {
                         age_group = AgeGroups::a18to29; /* single adult age 19-29 */
                     }
-                    setAgentDataAndAssignSchool(ptd, ip, i, j, k, dx, pid+ip, my_proc, age_group, family, nborhood, n_disease, nr_arr, student_counts_arr, engine);
+                    setAgentDataAndAssignSchool(ptd, ip, i, j, k, dx, pid + ip, my_proc, age_group, family, nborhood, n_disease,
+                                                nr_arr, student_counts_arr, engine);
                 } else if (family_size == 2) {
                     if (il2 == 0) {
                         /* 1% probability of one parent + one child */
@@ -324,13 +325,15 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
                         } else {
                             age_group = AgeGroups::a18to29; /* one parent 19-29 */
                         }
-                        setAgentDataAndAssignSchool(ptd, ip, i, j, k, dx, pid+ip, my_proc, age_group, family, nborhood, n_disease, nr_arr, student_counts_arr, engine);
+                        setAgentDataAndAssignSchool(ptd, ip, i, j, k, dx, pid + ip, my_proc, age_group, family, nborhood,
+                                                    n_disease, nr_arr, student_counts_arr, engine);
                         if (((int)Random_int(100, engine)) < p_schoolage) {
                             age_group = AgeGroups::a5to17;
                         } else {
                             age_group = AgeGroups::u5;
                         }
-                        setAgentDataAndAssignSchool(ptd, ip+1, i, j, k, dx, pid+ip+1, my_proc, age_group, family, nborhood, n_disease, nr_arr, student_counts_arr, engine);
+                        setAgentDataAndAssignSchool(ptd, ip + 1, i, j, k, dx, pid + ip + 1, my_proc, age_group, family, nborhood,
+                                                    n_disease, nr_arr, student_counts_arr, engine);
                     } else {
                         /* 2 adults, 28% over 65 (ASSUME both same age group) */
                         if (il2 < 28) {
@@ -342,9 +345,11 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
                         } else {
                             age_group = AgeGroups::a18to29; /* single adult age 19-29 */
                         }
-                        setAgentDataAndAssignSchool(ptd, ip, i, j, k, dx, pid+ip, my_proc, age_group, family, nborhood, n_disease, nr_arr, student_counts_arr, engine);
-                        setAgentDataAndAssignSchool(ptd, ip+1, i, j, k, dx, pid+ip+1, my_proc, age_group, family, nborhood, n_disease, nr_arr, student_counts_arr, engine);
-            }
+                        setAgentDataAndAssignSchool(ptd, ip, i, j, k, dx, pid + ip, my_proc, age_group, family, nborhood,
+                                                    n_disease, nr_arr, student_counts_arr, engine);
+                        setAgentDataAndAssignSchool(ptd, ip + 1, i, j, k, dx, pid + ip + 1, my_proc, age_group, family, nborhood,
+                                                    n_disease, nr_arr, student_counts_arr, engine);
+                    }
                 }
 
                 if (family_size > 2) {
@@ -358,8 +363,10 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
                     } else {
                         age_group = AgeGroups::a18to29; /* parents 19-29 */
                     }
-                    setAgentDataAndAssignSchool(ptd, ip, i, j, k, dx, pid+ip, my_proc, age_group, family, nborhood, n_disease, nr_arr, student_counts_arr, engine);
-                    setAgentDataAndAssignSchool(ptd, ip+1, i, j, k, dx, pid+ip+1, my_proc, age_group, family, nborhood, n_disease, nr_arr, student_counts_arr, engine);
+                    setAgentDataAndAssignSchool(ptd, ip, i, j, k, dx, pid + ip, my_proc, age_group, family, nborhood, n_disease,
+                                                nr_arr, student_counts_arr, engine);
+                    setAgentDataAndAssignSchool(ptd, ip + 1, i, j, k, dx, pid + ip + 1, my_proc, age_group, family, nborhood,
+                                                n_disease, nr_arr, student_counts_arr, engine);
 
                     /* Now pick the children's age groups */
                     for (int nc = 2; nc < family_size; ++nc) {
@@ -368,7 +375,8 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
                         } else {
                             age_group = AgeGroups::u5;
                         }
-                        setAgentDataAndAssignSchool(ptd, ip+nc, i, j, k, dx, pid+ip+nc, my_proc, age_group, family, nborhood, n_disease, nr_arr, student_counts_arr, engine);
+                        setAgentDataAndAssignSchool(ptd, ip + nc, i, j, k, dx, pid + ip + nc, my_proc, age_group, family,
+                                                    nborhood, n_disease, nr_arr, student_counts_arr, engine);
                     }
                 }
             }

--- a/src/CensusData.cpp
+++ b/src/CensusData.cpp
@@ -306,7 +306,6 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
             int community = comm_arr(i, j, k);
             int family_id_start = fam_id_arr(i, j, k, n);
             int family_size = n + 1;
-            int num_to_add = family_size * nf;
 
             int community_size;
             if (Population[unit] < (1000 + DemographicData::COMMUNITY_SIZE * (community - Start[unit]))) {
@@ -326,11 +325,13 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
 
             int start = offset_arr(i, j, k, n);
             int nborhood = 0;
-            for (int ii = 0; ii < num_to_add; ++ii) {
+            for (int ifam = 0; ifam < nf; ++ifam) {
+                int family = family_id_start + ifam;
+                int ii = family_size*ifam;
                 int ip = start + ii;
-                auto& agent = aos[ip];
+
                 int il2 = Random_int(100, engine);
-                if (ii % family_size == 0) { nborhood = Random_int(DemographicData::COMMUNITY_SIZE / nborhood_size, engine); }
+                nborhood = Random_int(DemographicData::COMMUNITY_SIZE / nborhood_size, engine);
                 int age_group = -1;
 
                 if (family_size == 1) {
@@ -344,6 +345,7 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
                         age_group = AgeGroups::a18to29; /* single adult age 19-29 */
                     }
                     nr_arr(i, j, k, age_group) += 1;
+                    setAgentData(ptd, ip, i, j, dx, pid+ip, my_proc, age_group, family, nborhood, n_disease);
                 } else if (family_size == 2) {
                     if (il2 == 0) {
                         /* 1% probability of one parent + one child */
@@ -358,12 +360,14 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
                             age_group = AgeGroups::a18to29; /* one parent 19-29 */
                         }
                         nr_arr(i, j, k, age_group) += 1;
+                        setAgentData(ptd, ip, i, j, dx, pid+ip, my_proc, age_group, family, nborhood, n_disease);
                         if (((int)Random_int(100, engine)) < p_schoolage) {
                             age_group = AgeGroups::a5to17;
                         } else {
                             age_group = AgeGroups::u5;
                         }
                         nr_arr(i, j, k, age_group) += 1;
+                        setAgentData(ptd, ip+1, i, j, dx, pid+ip+1, my_proc, age_group, family, nborhood, n_disease);
                     } else {
                         /* 2 adults, 28% over 65 (ASSUME both same age group) */
                         if (il2 < 28) {
@@ -376,6 +380,8 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
                             age_group = AgeGroups::a18to29; /* single adult age 19-29 */
                         }
                         nr_arr(i, j, k, age_group) += 2;
+                        setAgentData(ptd, ip, i, j, dx, pid+ip, my_proc, age_group, family, nborhood, n_disease);
+                        setAgentData(ptd, ip+1, i, j, dx, pid+ip+1, my_proc, age_group, family, nborhood, n_disease)
                     }
                 }
 
@@ -391,6 +397,8 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
                         age_group = AgeGroups::a18to29; /* parents 19-29 */
                     }
                     nr_arr(i, j, k, age_group) += 2;
+                    setAgentData(ptd, ip, i, j, dx, pid+ip, my_proc, age_group, family, nborhood, n_disease);
+                    setAgentData(ptd, ip+1, i, j, dx, pid+ip+1, my_proc, age_group, family, nborhood, n_disease)
 
                     /* Now pick the children's age groups */
                     for (int nc = 2; nc < family_size; ++nc) {
@@ -400,35 +408,9 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
                             age_group = AgeGroups::u5;
                         }
                         nr_arr(i, j, k, age_group) += 1;
+                        setAgentData(ptd, ip+nc, i, j, dx, pid+ip+nc, my_proc, age_group, family, nborhood, n_disease)
                     }
                 }
-
-                agent.pos(0) = static_cast<ParticleReal>((i + 0.5_rt) * dx[0]);
-                agent.pos(1) = static_cast<ParticleReal>((j + 0.5_rt) * dx[1]);
-                agent.id() = pid + ip;
-                agent.cpu() = my_proc;
-
-                for (int d = 0; d < n_disease; d++) {
-                    status_ptrs[d][ip] = 0;
-                    counter_ptrs[d][ip] = 0.0_prt;
-                    timer_ptrs[d][ip] = 0.0_prt;
-                }
-                age_group_ptr[ip] = age_group;
-                family_ptr[ip] = family_id_start + (ii / family_size);
-                home_i_ptr[ip] = i;
-                home_j_ptr[ip] = j;
-                work_i_ptr[ip] = i;
-                work_j_ptr[ip] = j;
-                trav_i_ptr[ip] = i;
-                trav_j_ptr[ip] = j;
-                hosp_i_ptr[ip] = -1;
-                hosp_j_ptr[ip] = -1;
-                nborhood_ptr[ip] = nborhood;
-                work_nborhood_ptr[ip] = nborhood;
-                workgroup_ptr[ip] = 0;
-                naics_ptr[ip] = 0;
-                random_travel_ptr[ip] = -1;
-                air_travel_ptr[ip] = -1;
 
                 assignSchool(&school_grade_ptr[ip], &school_id_ptr[ip], age_group, nborhood, engine);
 

--- a/src/CensusData.cpp
+++ b/src/CensusData.cpp
@@ -248,10 +248,10 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
         auto student_counts_arr = pc.m_student_counts[mfi].array();
         auto& agents_tile = pc.DefineAndReturnParticleTile(0, mfi);
         agents_tile.resize(nagents);
-	auto ptd = agents_tile.getParticleTileData();
+    auto ptd = agents_tile.getParticleTileData();
         auto dx = pc.ParticleGeom(0).CellSizeArray();
         auto my_proc = ParallelDescriptor::MyProc();
-	int n_disease = pc.m_num_diseases;
+    int n_disease = pc.m_num_diseases;
 
         Long pid;
 #ifdef AMREX_USE_OMP
@@ -344,7 +344,7 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
                         }
                         setAgentDataAndAssignSchool(ptd, ip, i, j, k, dx, pid+ip, my_proc, age_group, family, nborhood, n_disease, nr_arr, student_counts_arr, engine);
                         setAgentDataAndAssignSchool(ptd, ip+1, i, j, k, dx, pid+ip+1, my_proc, age_group, family, nborhood, n_disease, nr_arr, student_counts_arr, engine);
-		    }
+            }
                 }
 
                 if (family_size > 2) {

--- a/src/CensusData.cpp
+++ b/src/CensusData.cpp
@@ -245,47 +245,13 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
 
         auto offset_arr = fam_offsets[mfi].array();
         auto fam_id_arr = fam_id[mfi].array();
+        auto student_counts_arr = pc.m_student_counts[mfi].array();
         auto& agents_tile = pc.DefineAndReturnParticleTile(0, mfi);
         agents_tile.resize(nagents);
-        auto aos = &agents_tile.GetArrayOfStructs()[0];
-        auto& soa = agents_tile.GetStructOfArrays();
-
-        auto age_group_ptr = soa.GetIntData(IntIdx::age_group).data();
-        auto family_ptr = soa.GetIntData(IntIdx::family).data();
-        auto home_i_ptr = soa.GetIntData(IntIdx::home_i).data();
-        auto home_j_ptr = soa.GetIntData(IntIdx::home_j).data();
-        auto work_i_ptr = soa.GetIntData(IntIdx::work_i).data();
-        auto work_j_ptr = soa.GetIntData(IntIdx::work_j).data();
-        auto trav_i_ptr = soa.GetIntData(IntIdx::trav_i).data();
-        auto trav_j_ptr = soa.GetIntData(IntIdx::trav_j).data();
-        auto hosp_i_ptr = soa.GetIntData(IntIdx::hosp_i).data();
-        auto hosp_j_ptr = soa.GetIntData(IntIdx::hosp_j).data();
-        auto nborhood_ptr = soa.GetIntData(IntIdx::nborhood).data();
-        auto school_grade_ptr = soa.GetIntData(IntIdx::school_grade).data();
-        auto school_id_ptr = soa.GetIntData(IntIdx::school_id).data();
-        auto school_closed_ptr = soa.GetIntData(IntIdx::school_closed).data();
-        auto naics_ptr = soa.GetIntData(IntIdx::naics).data();
-        auto workgroup_ptr = soa.GetIntData(IntIdx::workgroup).data();
-        auto work_nborhood_ptr = soa.GetIntData(IntIdx::work_nborhood).data();
-        auto random_travel_ptr = soa.GetIntData(IntIdx::random_travel).data();
-        auto air_travel_ptr = soa.GetIntData(IntIdx::air_travel).data();
-
-        int i_RT = IntIdx::nattribs;
-        int r_RT = RealIdx::nattribs;
-        int n_disease = pc.m_num_diseases;
-
-        GpuArray<int*, ExaEpi::max_num_diseases> status_ptrs;
-        GpuArray<ParticleReal*, ExaEpi::max_num_diseases> counter_ptrs, timer_ptrs;
-        for (int d = 0; d < n_disease; d++) {
-            status_ptrs[d] = soa.GetIntData(i_RT + i0(d) + IntIdxDisease::status).data();
-            counter_ptrs[d] = soa.GetRealData(r_RT + r0(d) + RealIdxDisease::disease_counter).data();
-            timer_ptrs[d] = soa.GetRealData(r_RT + r0(d) + RealIdxDisease::treatment_timer).data();
-        }
-
+	auto ptd = agents_tile.getParticleTileData();
         auto dx = pc.ParticleGeom(0).CellSizeArray();
         auto my_proc = ParallelDescriptor::MyProc();
-
-        auto student_counts_arr = pc.m_student_counts[mfi].array();
+	int n_disease = pc.m_num_diseases;
 
         Long pid;
 #ifdef AMREX_USE_OMP
@@ -344,8 +310,7 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
                     } else {
                         age_group = AgeGroups::a18to29; /* single adult age 19-29 */
                     }
-                    nr_arr(i, j, k, age_group) += 1;
-                    setAgentData(ptd, ip, i, j, dx, pid+ip, my_proc, age_group, family, nborhood, n_disease);
+                    setAgentDataAndAssignSchool(ptd, ip, i, j, k, dx, pid+ip, my_proc, age_group, family, nborhood, n_disease, nr_arr, student_counts_arr, engine);
                 } else if (family_size == 2) {
                     if (il2 == 0) {
                         /* 1% probability of one parent + one child */
@@ -359,15 +324,13 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
                         } else {
                             age_group = AgeGroups::a18to29; /* one parent 19-29 */
                         }
-                        nr_arr(i, j, k, age_group) += 1;
-                        setAgentData(ptd, ip, i, j, dx, pid+ip, my_proc, age_group, family, nborhood, n_disease);
+                        setAgentDataAndAssignSchool(ptd, ip, i, j, k, dx, pid+ip, my_proc, age_group, family, nborhood, n_disease, nr_arr, student_counts_arr, engine);
                         if (((int)Random_int(100, engine)) < p_schoolage) {
                             age_group = AgeGroups::a5to17;
                         } else {
                             age_group = AgeGroups::u5;
                         }
-                        nr_arr(i, j, k, age_group) += 1;
-                        setAgentData(ptd, ip+1, i, j, dx, pid+ip+1, my_proc, age_group, family, nborhood, n_disease);
+                        setAgentDataAndAssignSchool(ptd, ip+1, i, j, k, dx, pid+ip+1, my_proc, age_group, family, nborhood, n_disease, nr_arr, student_counts_arr, engine);
                     } else {
                         /* 2 adults, 28% over 65 (ASSUME both same age group) */
                         if (il2 < 28) {
@@ -379,10 +342,9 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
                         } else {
                             age_group = AgeGroups::a18to29; /* single adult age 19-29 */
                         }
-                        nr_arr(i, j, k, age_group) += 2;
-                        setAgentData(ptd, ip, i, j, dx, pid+ip, my_proc, age_group, family, nborhood, n_disease);
-                        setAgentData(ptd, ip+1, i, j, dx, pid+ip+1, my_proc, age_group, family, nborhood, n_disease)
-                    }
+                        setAgentDataAndAssignSchool(ptd, ip, i, j, k, dx, pid+ip, my_proc, age_group, family, nborhood, n_disease, nr_arr, student_counts_arr, engine);
+                        setAgentDataAndAssignSchool(ptd, ip+1, i, j, k, dx, pid+ip+1, my_proc, age_group, family, nborhood, n_disease, nr_arr, student_counts_arr, engine);
+		    }
                 }
 
                 if (family_size > 2) {
@@ -396,9 +358,8 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
                     } else {
                         age_group = AgeGroups::a18to29; /* parents 19-29 */
                     }
-                    nr_arr(i, j, k, age_group) += 2;
-                    setAgentData(ptd, ip, i, j, dx, pid+ip, my_proc, age_group, family, nborhood, n_disease);
-                    setAgentData(ptd, ip+1, i, j, dx, pid+ip+1, my_proc, age_group, family, nborhood, n_disease)
+                    setAgentDataAndAssignSchool(ptd, ip, i, j, k, dx, pid+ip, my_proc, age_group, family, nborhood, n_disease, nr_arr, student_counts_arr, engine);
+                    setAgentDataAndAssignSchool(ptd, ip+1, i, j, k, dx, pid+ip+1, my_proc, age_group, family, nborhood, n_disease, nr_arr, student_counts_arr, engine);
 
                     /* Now pick the children's age groups */
                     for (int nc = 2; nc < family_size; ++nc) {
@@ -407,20 +368,8 @@ void CensusData::initAgents (AgentContainer& pc, /*!< Agents */
                         } else {
                             age_group = AgeGroups::u5;
                         }
-                        nr_arr(i, j, k, age_group) += 1;
-                        setAgentData(ptd, ip+nc, i, j, dx, pid+ip+nc, my_proc, age_group, family, nborhood, n_disease)
+                        setAgentDataAndAssignSchool(ptd, ip+nc, i, j, k, dx, pid+ip+nc, my_proc, age_group, family, nborhood, n_disease, nr_arr, student_counts_arr, engine);
                     }
-                }
-
-                assignSchool(&school_grade_ptr[ip], &school_id_ptr[ip], age_group, nborhood, engine);
-
-                school_closed_ptr[ip] = 0;
-
-                // Increment the appropriate student counter based on the school assignment
-                if (school_id_ptr[ip] >= SchoolCensusIDType::daycare_5) {
-                    Gpu::Atomic::AddNoRet(&student_counts_arr(i, j, k, SchoolCensusIDType::daycare_5 - 1), 1);
-                } else if (school_id_ptr[ip] > SchoolCensusIDType::none) {
-                    Gpu::Atomic::AddNoRet(&student_counts_arr(i, j, k, school_id_ptr[ip] - 1), 1);
                 }
             }
         });


### PR DESCRIPTION
This fixes a bug in the age group initialization for census data initial conditions. Should have no effect on runs with UrbanPop. 

The new age group distribution:

```
Age group counts (percentage):
  under 5   622994 9.1
  5 to 17    1739824 25.5
  18 to 29   1566095 23.0
  30 to 49   1271414 18.6
  50 to 64   957842 14.0
  over 64    659372 9.7
  Total      6817541
```

Daily cases for a bay area run using dev and this branch:

<img width="640" height="480" alt="age_group_fix" src="https://github.com/user-attachments/assets/b3877f65-0cdc-4fde-aef4-aa29f53aa434" />
