### PR TITLE
Fix multi-disease hospital stats bug

### DIFF
--- a/src/DiseaseParm.H
+++ b/src/DiseaseParm.H
@@ -159,8 +159,6 @@ struct DiseaseParm {
                                const amrex::Real a_random_draw, /*!< random number */
                                const amrex::RandomEngine& a_reng /*!< random engine */) const {
         *a_t_hosp_days = ParticleReal(0);
-        *a_ICU = 0;
-        *a_ventilator = 0;
         // check the agent will be hospitalized (m_CHR prob)
         if (a_random_draw < m_CHR[a_age_group]) {
             // determine how long agent will stay in hospital

--- a/src/HospitalModel.H
+++ b/src/HospitalModel.H
@@ -172,6 +172,13 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                 Gpu::synchronize();
             }
 
+            Gpu::DeviceVector<int> released_from_hosp(np, 0);
+            Gpu::DeviceVector<int> released_from_ICU(np, 0);
+            Gpu::DeviceVector<int> released_from_vent(np, 0);
+            auto released_from_hosp_ptr = released_from_hosp.data();
+            auto released_from_ICU_ptr  = released_from_ICU.data();
+            auto released_from_vent_ptr = released_from_vent.data();
+
             ParallelFor(np, [=] AMREX_GPU_DEVICE (int i) noexcept {
                 if (!inHospital(i, ptd)) { return; }
 
@@ -183,6 +190,15 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                     hosp_i_ptr[i] = -1;
                     hosp_j_ptr[i] = -1;
                     withdrawn_ptr[i] = 0;
+                    if (std::abs(flag_status_ptr[i]) > DiseaseStats::hospitalization) {
+                        released_from_hosp_ptr[i] = 1;
+                    }
+                    if (std::abs(flag_status_ptr[i]) > DiseaseStats::ICU) {
+                        released_from_ICU_ptr[i] = 1;
+                    }
+                    if (std::abs(flag_status_ptr[i]) > DiseaseStats::ventilator) {
+                        released_from_vent_ptr[i] = 1;
+                    }
                 } else {
                     // check if agent can be discharged from hospital
                     ParticleReal sum_timers = 0;
@@ -197,6 +213,15 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                         PType& p = pstruct[i];
                         p.pos(0) = static_cast<ParticleReal>((home_i_ptr[i] + 0.5_rt) * dx[0]);
                         p.pos(1) = static_cast<ParticleReal>((home_j_ptr[i] + 0.5_rt) * dx[1]);
+                        if (std::abs(flag_status_ptr[i]) > DiseaseStats::hospitalization) {
+                            released_from_hosp_ptr[i] = 1;
+                        }
+                        if (std::abs(flag_status_ptr[i]) > DiseaseStats::ICU) {
+                            released_from_ICU_ptr[i] = 1;
+                        }
+                        if (std::abs(flag_status_ptr[i]) > DiseaseStats::ventilator) {
+                            released_from_vent_ptr[i] = 1;
+                        }
                     }
                 }
             });
@@ -209,13 +234,13 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                     if (flag_status_ptr[i] < 0) {
                         Gpu::Atomic::AddNoRet(&ds_arr(home_i_ptr[i], home_j_ptr[i], 0, DiseaseStats::death), 1.0_rt);
                     }
-                    if (std::abs(flag_status_ptr[i]) > DiseaseStats::hospitalization) {
+                    if (released_from_hosp[i]) {
                         Gpu::Atomic::AddNoRet(&ds_arr(home_i_ptr[i], home_j_ptr[i], 0, DiseaseStats::hospitalization), -1.0_rt);
                     }
-                    if (std::abs(flag_status_ptr[i]) > DiseaseStats::ICU) {
+                    if (released_from_ICU[i]) {
                         Gpu::Atomic::AddNoRet(&ds_arr(home_i_ptr[i], home_j_ptr[i], 0, DiseaseStats::ICU), -1.0_rt);
                     }
-                    if (std::abs(flag_status_ptr[i]) > DiseaseStats::ventilator) {
+                    if (released_from_vent[i]) {
                         Gpu::Atomic::AddNoRet(&ds_arr(home_i_ptr[i], home_j_ptr[i], 0, DiseaseStats::ventilator), -1.0_rt);
                     }
                 });

--- a/src/HospitalModel.H
+++ b/src/HospitalModel.H
@@ -94,12 +94,12 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
             auto is_alive_ptr = is_alive.data();
 
             Gpu::DeviceVector<int> died_today(np, 0);
-            Gpu::DeviceVector<int> exit_hosp(np*n_disease, -1);
-            Gpu::DeviceVector<int> exit_ICU(np*n_disease, -1);
-            Gpu::DeviceVector<int> exit_vent(np*n_disease, -1);
+            Gpu::DeviceVector<int> exit_hosp(np * n_disease, -1);
+            Gpu::DeviceVector<int> exit_ICU(np * n_disease, -1);
+            Gpu::DeviceVector<int> exit_vent(np * n_disease, -1);
             auto died_today_ptr = died_today.data();
             auto exit_hosp_ptr = exit_hosp.data();
-            auto exit_ICU_ptr  = exit_ICU.data();
+            auto exit_ICU_ptr = exit_ICU.data();
             auto exit_vent_ptr = exit_vent.data();
 
             ParallelFor(np, [=] AMREX_GPU_DEVICE (int i) noexcept {
@@ -146,23 +146,23 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                     AMREX_ALWAYS_ASSERT(status_ptrs[d][i] == Status::infected);
                     // check for exit conditions
                     if (timer_ptrs[d][i] > 2 * disease_parm_d->m_t_hosp_offset + 1) {
-                        exit_vent_ptr[d*np+i] = 0;
-                        exit_ICU_ptr[d*np+i] = 0;
-                        exit_hosp_ptr[d*np+i] = 0;
+                        exit_vent_ptr[d * np + i] = 0;
+                        exit_ICU_ptr[d * np + i] = 0;
+                        exit_hosp_ptr[d * np + i] = 0;
                     } else if (timer_ptrs[d][i] == 2 * disease_parm_d->m_t_hosp_offset + 1) {
-                        exit_vent_ptr[d*np+i] = 1;
-                        exit_ICU_ptr[d*np+i] = 1;
-                        exit_hosp_ptr[d*np+i] = 1;
+                        exit_vent_ptr[d * np + i] = 1;
+                        exit_ICU_ptr[d * np + i] = 1;
+                        exit_hosp_ptr[d * np + i] = 1;
                     } else if (timer_ptrs[d][i] > disease_parm_d->m_t_hosp_offset + 1) {
-                        exit_ICU_ptr[d*np+i] = 0;
-                        exit_hosp_ptr[d*np+i] = 0;
+                        exit_ICU_ptr[d * np + i] = 0;
+                        exit_hosp_ptr[d * np + i] = 0;
                     } else if (timer_ptrs[d][i] == disease_parm_d->m_t_hosp_offset + 1) {
-                        exit_ICU_ptr[d*np+i] = 1;
-                        exit_hosp_ptr[d*np+i] = 1;
+                        exit_ICU_ptr[d * np + i] = 1;
+                        exit_hosp_ptr[d * np + i] = 1;
                     } else if (timer_ptrs[d][i] > 1) {
-                        exit_hosp_ptr[d*np+i] = 0;
+                        exit_hosp_ptr[d * np + i] = 0;
                     } else if (timer_ptrs[d][i] == 1) {
-                        exit_hosp_ptr[d*np+i] = 1;
+                        exit_hosp_ptr[d * np + i] = 1;
                     }
                     // decrement days in hospital
                     timer_ptrs[d][i] -= 1.0_prt;
@@ -180,7 +180,7 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
 
                     if (status_d > 0) {
                         // Check if hospitalized patient recovers or dies
-                        if (Random(engine) < disease_parm_d->m_hospToDeath[status_d-1][age_group_ptr[i]]) {
+                        if (Random(engine) < disease_parm_d->m_hospToDeath[status_d - 1][age_group_ptr[i]]) {
                             is_alive_ptr[i] = 0;
                             died_today_ptr[i] = 1;
                             status_ptrs[d][i] = Status::dead;
@@ -203,7 +203,7 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
             Gpu::DeviceVector<int> rm_from_ICU(np, 0);
             Gpu::DeviceVector<int> rm_from_vent(np, 0);
             auto rm_from_hosp_ptr = rm_from_hosp.data();
-            auto rm_from_ICU_ptr  = rm_from_ICU.data();
+            auto rm_from_ICU_ptr = rm_from_ICU.data();
             auto rm_from_vent_ptr = rm_from_vent.data();
 
             ParallelFor(np, [=] AMREX_GPU_DEVICE (int i) noexcept {
@@ -216,9 +216,18 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                 int count_i = 0;
                 int count_v = 0;
                 for (int d = 0; d < n_disease; d++) {
-                    if (exit_hosp_ptr[d*np+i] > 0) { rm_from_hosp_ptr[i] *= exit_hosp_ptr[d*np+i]; count_h++; }
-                    if (exit_ICU_ptr[d*np+i] > 0)  { rm_from_ICU_ptr[i] *= exit_ICU_ptr[d*np+i]; count_i++; }
-                    if (exit_vent_ptr[d*np+i] > 0) { rm_from_vent_ptr[i] *= exit_vent_ptr[d*np+i]; count_v++; }
+                    if (exit_hosp_ptr[d * np + i] > 0) {
+                        rm_from_hosp_ptr[i] *= exit_hosp_ptr[d * np + i];
+                        count_h++;
+                    }
+                    if (exit_ICU_ptr[d * np + i] > 0) {
+                        rm_from_ICU_ptr[i] *= exit_ICU_ptr[d * np + i];
+                        count_i++;
+                    }
+                    if (exit_vent_ptr[d * np + i] > 0) {
+                        rm_from_vent_ptr[i] *= exit_vent_ptr[d * np + i];
+                        count_v++;
+                    }
                 }
                 if (count_h == 0) { rm_from_hosp_ptr[i] = 0; }
                 if (count_i == 0) { rm_from_ICU_ptr[i] = 0; }
@@ -247,7 +256,7 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                         p.pos(0) = static_cast<ParticleReal>((home_i_ptr[i] + 0.5_rt) * dx[0]);
                         p.pos(1) = static_cast<ParticleReal>((home_j_ptr[i] + 0.5_rt) * dx[1]);
                     } else {
-                      AMREX_ALWAYS_ASSERT(!rm_from_hosp_ptr[i]);
+                        AMREX_ALWAYS_ASSERT(!rm_from_hosp_ptr[i]);
                     }
                 }
             });

--- a/src/HospitalModel.H
+++ b/src/HospitalModel.H
@@ -93,9 +93,6 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
             Gpu::DeviceVector<int> is_alive(np);
             auto is_alive_ptr = is_alive.data();
 
-            Gpu::DeviceVector<int> flag_status(np);
-            auto flag_status_ptr = flag_status.data();
-
             Gpu::DeviceVector<int> exit_hosp(np*n_disease, -1);
             Gpu::DeviceVector<int> exit_ICU(np*n_disease, -1);
             Gpu::DeviceVector<int> exit_vent(np*n_disease, -1);
@@ -116,7 +113,6 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                         AMREX_ALWAYS_ASSERT(status_ptrs[d][i] != Status::dead);
                     }
                 }
-                flag_status_ptr[i] = 0; // 0: nothing changed on this day
             });
             Gpu::synchronize();
 
@@ -168,22 +164,22 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                     }
                     // decrement days in hospital
                     timer_ptrs[d][i] -= 1.0_prt;
+                    int status_d = 0;
                     if (timer_ptrs[d][i] == 0) {
                         // finished hospitalization period
-                        flag_status_ptr[i] = DiseaseStats::hospitalization + 1;
+                        status_d = DiseaseStats::hospitalization + 1;
                     } else if (timer_ptrs[d][i] == disease_parm_d->m_t_hosp_offset) {
                         // finished ICU hospitalization period, counted down to m_t_hosp_offset
-                        flag_status_ptr[i] = DiseaseStats::ICU + 1;
+                        status_d = DiseaseStats::ICU + 1;
                     } else if (timer_ptrs[d][i] == 2 * disease_parm_d->m_t_hosp_offset) {
                         // finished ventilator hospitalization period, counted down to 2 * m_t_hosp_offset
-                        flag_status_ptr[i] = DiseaseStats::ventilator + 1;
+                        status_d = DiseaseStats::ventilator + 1;
                     }
 
-                    if (flag_status_ptr[i] > 0) {
+                    if (status_d > 0) {
                         // Check if hospitalized patient recovers or dies
-                        if (Random(engine) < disease_parm_d->m_hospToDeath[flag_status_ptr[i] - 1][age_group_ptr[i]]) {
+                        if (Random(engine) < disease_parm_d->m_hospToDeath[status_d-1][age_group_ptr[i]]) {
                             is_alive_ptr[i] = 0;
-                            flag_status_ptr[i] *= -1;
                             status_ptrs[d][i] = Status::dead;
                         } else {
                             // If alive, hospitalized patient recovers
@@ -258,7 +254,7 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
             for (int d = 0; d < n_disease; d++) {
                 auto ds_arr = (*a_dstats[d])[mfi].array();
                 ParallelFor(np, [=] AMREX_GPU_DEVICE (int i) noexcept {
-                    if (flag_status_ptr[i] < 0) {
+                    if (is_alive_ptr[i] == 0) {
                         Gpu::Atomic::AddNoRet(&ds_arr(home_i_ptr[i], home_j_ptr[i], 0, DiseaseStats::death), 1.0_rt);
                     }
                     if (rm_from_hosp_ptr[i]) {

--- a/src/HospitalModel.H
+++ b/src/HospitalModel.H
@@ -96,6 +96,13 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
             Gpu::DeviceVector<int> flag_status(np);
             auto flag_status_ptr = flag_status.data();
 
+            Gpu::DeviceVector<int> released_from_hosp(np, 0);
+            Gpu::DeviceVector<int> released_from_ICU(np, 0);
+            Gpu::DeviceVector<int> released_from_vent(np, 0);
+            auto released_from_hosp_ptr = released_from_hosp.data();
+            auto released_from_ICU_ptr  = released_from_ICU.data();
+            auto released_from_vent_ptr = released_from_vent.data();
+
             ParallelFor(np, [=] AMREX_GPU_DEVICE (int i) noexcept {
                 // if status_ptr for any one disease is dead, they should all be dead
                 if (status_ptrs[0][i] == Status::dead) {
@@ -144,12 +151,15 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                     if (timer_ptrs[d][i] == 0) {
                         // finished hospitalization period
                         flag_status_ptr[i] = DiseaseStats::hospitalization + 1;
+                        released_from_hosp_ptr[i] = 1;
                     } else if (timer_ptrs[d][i] == disease_parm_d->m_t_hosp_offset) {
                         // finished ICU hospitalization period, counted down to m_t_hosp_offset
                         flag_status_ptr[i] = DiseaseStats::ICU + 1;
+                        released_from_ICU_ptr[i] = 1;
                     } else if (timer_ptrs[d][i] == 2 * disease_parm_d->m_t_hosp_offset) {
                         // finished ventilator hospitalization period, counted down to 2 * m_t_hosp_offset
                         flag_status_ptr[i] = DiseaseStats::ventilator + 1;
+                        released_from_vent_ptr[i] = 1;
                     }
                     if (flag_status_ptr[i] > 0) {
                         // Check if hospitalized patient recovers or dies
@@ -172,13 +182,6 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                 Gpu::synchronize();
             }
 
-            Gpu::DeviceVector<int> released_from_hosp(np, 0);
-            Gpu::DeviceVector<int> released_from_ICU(np, 0);
-            Gpu::DeviceVector<int> released_from_vent(np, 0);
-            auto released_from_hosp_ptr = released_from_hosp.data();
-            auto released_from_ICU_ptr  = released_from_ICU.data();
-            auto released_from_vent_ptr = released_from_vent.data();
-
             ParallelFor(np, [=] AMREX_GPU_DEVICE (int i) noexcept {
                 if (!inHospital(i, ptd)) { return; }
 
@@ -190,15 +193,6 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                     hosp_i_ptr[i] = -1;
                     hosp_j_ptr[i] = -1;
                     withdrawn_ptr[i] = 0;
-                    if (std::abs(flag_status_ptr[i]) > DiseaseStats::hospitalization) {
-                        released_from_hosp_ptr[i] = 1;
-                    }
-                    if (std::abs(flag_status_ptr[i]) > DiseaseStats::ICU) {
-                        released_from_ICU_ptr[i] = 1;
-                    }
-                    if (std::abs(flag_status_ptr[i]) > DiseaseStats::ventilator) {
-                        released_from_vent_ptr[i] = 1;
-                    }
                 } else {
                     // check if agent can be discharged from hospital
                     ParticleReal sum_timers = 0;
@@ -213,15 +207,11 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                         PType& p = pstruct[i];
                         p.pos(0) = static_cast<ParticleReal>((home_i_ptr[i] + 0.5_rt) * dx[0]);
                         p.pos(1) = static_cast<ParticleReal>((home_j_ptr[i] + 0.5_rt) * dx[1]);
-                        if (std::abs(flag_status_ptr[i]) > DiseaseStats::hospitalization) {
-                            released_from_hosp_ptr[i] = 1;
-                        }
-                        if (std::abs(flag_status_ptr[i]) > DiseaseStats::ICU) {
-                            released_from_ICU_ptr[i] = 1;
-                        }
-                        if (std::abs(flag_status_ptr[i]) > DiseaseStats::ventilator) {
-                            released_from_vent_ptr[i] = 1;
-                        }
+                    } else {
+                        // do not release from hosp/ICU/vent
+                        released_from_hosp_ptr[i] = 0;
+                        released_from_ICU_ptr[i] = 0;
+                        released_from_vent_ptr[i] = 0;
                     }
                 }
             });

--- a/src/HospitalModel.H
+++ b/src/HospitalModel.H
@@ -155,10 +155,13 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                     } else if (timer_ptrs[d][i] == disease_parm_d->m_t_hosp_offset) {
                         // finished ICU hospitalization period, counted down to m_t_hosp_offset
                         flag_status_ptr[i] = DiseaseStats::ICU + 1;
+                        released_from_hosp_ptr[i] = 1;
                         released_from_ICU_ptr[i] = 1;
                     } else if (timer_ptrs[d][i] == 2 * disease_parm_d->m_t_hosp_offset) {
                         // finished ventilator hospitalization period, counted down to 2 * m_t_hosp_offset
                         flag_status_ptr[i] = DiseaseStats::ventilator + 1;
+                        released_from_hosp_ptr[i] = 1;
+                        released_from_ICU_ptr[i] = 1;
                         released_from_vent_ptr[i] = 1;
                     }
                     if (flag_status_ptr[i] > 0) {

--- a/src/HospitalModel.H
+++ b/src/HospitalModel.H
@@ -96,12 +96,12 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
             Gpu::DeviceVector<int> flag_status(np);
             auto flag_status_ptr = flag_status.data();
 
-            Gpu::DeviceVector<int> released_from_hosp(np, 0);
-            Gpu::DeviceVector<int> released_from_ICU(np, 0);
-            Gpu::DeviceVector<int> released_from_vent(np, 0);
-            auto released_from_hosp_ptr = released_from_hosp.data();
-            auto released_from_ICU_ptr  = released_from_ICU.data();
-            auto released_from_vent_ptr = released_from_vent.data();
+            Gpu::DeviceVector<int> exit_hosp(np*n_disease, 1);
+            Gpu::DeviceVector<int> exit_ICU(np*n_disease, 1);
+            Gpu::DeviceVector<int> exit_vent(np*n_disease, 1);
+            auto exit_hosp_ptr = exit_hosp.data();
+            auto exit_ICU_ptr  = exit_ICU.data();
+            auto exit_vent_ptr = exit_vent.data();
 
             ParallelFor(np, [=] AMREX_GPU_DEVICE (int i) noexcept {
                 // if status_ptr for any one disease is dead, they should all be dead
@@ -130,18 +130,30 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                 ParallelForRNG(np, [=] AMREX_GPU_DEVICE (int i, RandomEngine const& engine) noexcept {
                     if (!inHospital(i, ptd)) {
                         // agent is not in hospital
+                        exit_hosp_ptr[d*np+i] = 0;
+                        exit_ICU_ptr[d*np+i] = 0;
+                        exit_vent_ptr[d*np+i] = 0;
                         return;
                     }
                     if (counter_ptrs[d][i] == Math::floor(incubation_per_ptrs[d][i]) + Math::floor(hospital_delay_ptrs[d][i])) {
                         // agent just started treatment
+                        exit_hosp_ptr[d*np+i] = 0;
+                        exit_ICU_ptr[d*np+i] = 0;
+                        exit_vent_ptr[d*np+i] = 0;
                         return;
                     }
                     if (timer_ptrs[d][i] == 0) {
                         // agent has recovered/died from disease d
+                        exit_hosp_ptr[d*np+i] = 0;
+                        exit_ICU_ptr[d*np+i] = 0;
+                        exit_vent_ptr[d*np+i] = 0;
                         return;
                     }
                     if (is_alive_ptr[i] == 0) {
                         // agent is dead
+                        exit_hosp_ptr[d*np+i] = 0;
+                        exit_ICU_ptr[d*np+i] = 0;
+                        exit_vent_ptr[d*np+i] = 0;
                         return;
                     }
 
@@ -151,19 +163,24 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                     if (timer_ptrs[d][i] == 0) {
                         // finished hospitalization period
                         flag_status_ptr[i] = DiseaseStats::hospitalization + 1;
-                        released_from_hosp_ptr[i] = 1;
                     } else if (timer_ptrs[d][i] == disease_parm_d->m_t_hosp_offset) {
                         // finished ICU hospitalization period, counted down to m_t_hosp_offset
                         flag_status_ptr[i] = DiseaseStats::ICU + 1;
-                        released_from_hosp_ptr[i] = 1;
-                        released_from_ICU_ptr[i] = 1;
                     } else if (timer_ptrs[d][i] == 2 * disease_parm_d->m_t_hosp_offset) {
                         // finished ventilator hospitalization period, counted down to 2 * m_t_hosp_offset
                         flag_status_ptr[i] = DiseaseStats::ventilator + 1;
-                        released_from_hosp_ptr[i] = 1;
-                        released_from_ICU_ptr[i] = 1;
-                        released_from_vent_ptr[i] = 1;
                     }
+                    // check for exit conditions
+                    if (timer_ptrs[d][i] != 2 * disease_parm_d->m_t_hosp_offset) {
+                        exit_vent_ptr[d*np+i] = 0;
+                    }
+                    if (timer_ptrs[d][i] != disease_parm_d->m_t_hosp_offset) {
+                        exit_ICU_ptr[d*np+i] = 0;
+                    }
+                    if (timer_ptrs[d][i] != 0) {
+                        exit_hosp_ptr[d*np+i] = 0;
+                    }
+
                     if (flag_status_ptr[i] > 0) {
                         // Check if hospitalized patient recovers or dies
                         if (Random(engine) < disease_parm_d->m_hospToDeath[flag_status_ptr[i] - 1][age_group_ptr[i]]) {
@@ -185,8 +202,24 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                 Gpu::synchronize();
             }
 
+            Gpu::DeviceVector<int> released_from_hosp(np, 0);
+            Gpu::DeviceVector<int> released_from_ICU(np, 0);
+            Gpu::DeviceVector<int> released_from_vent(np, 0);
+            auto released_from_hosp_ptr = released_from_hosp.data();
+            auto released_from_ICU_ptr  = released_from_ICU.data();
+            auto released_from_vent_ptr = released_from_vent.data();
+
             ParallelFor(np, [=] AMREX_GPU_DEVICE (int i) noexcept {
                 if (!inHospital(i, ptd)) { return; }
+
+                released_from_hosp_ptr[i] = 1;
+                released_from_ICU_ptr[i] = 1;
+                released_from_vent_ptr[i] = 1;
+                for (int d = 0; d < n_disease; d++) {
+                    released_from_hosp_ptr[i] *= exit_hosp_ptr[d*np+i];
+                    released_from_ICU_ptr[i] *= exit_ICU_ptr[d*np+i];
+                    released_from_vent_ptr[i] *= exit_vent_ptr[d*np+i];
+                }
 
                 if (is_alive_ptr[i] == 0) {
                     // agent has died
@@ -211,10 +244,7 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                         p.pos(0) = static_cast<ParticleReal>((home_i_ptr[i] + 0.5_rt) * dx[0]);
                         p.pos(1) = static_cast<ParticleReal>((home_j_ptr[i] + 0.5_rt) * dx[1]);
                     } else {
-                        // do not release from hosp/ICU/vent
-                        released_from_hosp_ptr[i] = 0;
-                        released_from_ICU_ptr[i] = 0;
-                        released_from_vent_ptr[i] = 0;
+                      AMREX_ALWAYS_ASSERT(!released_from_hosp_ptr[i]);
                     }
                 }
             });

--- a/src/HospitalModel.H
+++ b/src/HospitalModel.H
@@ -93,9 +93,11 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
             Gpu::DeviceVector<int> is_alive(np);
             auto is_alive_ptr = is_alive.data();
 
+            Gpu::DeviceVector<int> died_today(np, 0);
             Gpu::DeviceVector<int> exit_hosp(np*n_disease, -1);
             Gpu::DeviceVector<int> exit_ICU(np*n_disease, -1);
             Gpu::DeviceVector<int> exit_vent(np*n_disease, -1);
+            auto died_today_ptr = died_today.data();
             auto exit_hosp_ptr = exit_hosp.data();
             auto exit_ICU_ptr  = exit_ICU.data();
             auto exit_vent_ptr = exit_vent.data();
@@ -180,6 +182,7 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                         // Check if hospitalized patient recovers or dies
                         if (Random(engine) < disease_parm_d->m_hospToDeath[status_d-1][age_group_ptr[i]]) {
                             is_alive_ptr[i] = 0;
+                            died_today_ptr[i] = 1;
                             status_ptrs[d][i] = Status::dead;
                         } else {
                             // If alive, hospitalized patient recovers
@@ -254,7 +257,7 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
             for (int d = 0; d < n_disease; d++) {
                 auto ds_arr = (*a_dstats[d])[mfi].array();
                 ParallelFor(np, [=] AMREX_GPU_DEVICE (int i) noexcept {
-                    if (is_alive_ptr[i] == 0) {
+                    if (died_today_ptr[i]) {
                         Gpu::Atomic::AddNoRet(&ds_arr(home_i_ptr[i], home_j_ptr[i], 0, DiseaseStats::death), 1.0_rt);
                     }
                     if (rm_from_hosp_ptr[i]) {

--- a/src/HospitalModel.H
+++ b/src/HospitalModel.H
@@ -200,24 +200,30 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                 Gpu::synchronize();
             }
 
-            Gpu::DeviceVector<int> released_from_hosp(np, 0);
-            Gpu::DeviceVector<int> released_from_ICU(np, 0);
-            Gpu::DeviceVector<int> released_from_vent(np, 0);
-            auto released_from_hosp_ptr = released_from_hosp.data();
-            auto released_from_ICU_ptr  = released_from_ICU.data();
-            auto released_from_vent_ptr = released_from_vent.data();
+            Gpu::DeviceVector<int> rm_from_hosp(np, 0);
+            Gpu::DeviceVector<int> rm_from_ICU(np, 0);
+            Gpu::DeviceVector<int> rm_from_vent(np, 0);
+            auto rm_from_hosp_ptr = rm_from_hosp.data();
+            auto rm_from_ICU_ptr  = rm_from_ICU.data();
+            auto rm_from_vent_ptr = rm_from_vent.data();
 
             ParallelFor(np, [=] AMREX_GPU_DEVICE (int i) noexcept {
                 if (!inHospital(i, ptd)) { return; }
 
-                released_from_hosp_ptr[i] = 1;
-                released_from_ICU_ptr[i] = 1;
-                released_from_vent_ptr[i] = 1;
+                rm_from_hosp_ptr[i] = 1;
+                rm_from_ICU_ptr[i] = 1;
+                rm_from_vent_ptr[i] = 1;
+                int count_h = 0;
+                int count_i = 0;
+                int count_v = 0;
                 for (int d = 0; d < n_disease; d++) {
-                    if (exit_hosp_ptr[d*np+i] > 0) { released_from_hosp_ptr[i] *= exit_hosp_ptr[d*np+i]; }
-                    if (exit_ICU_ptr[d*np+i] > 0)  { released_from_ICU_ptr[i] *= exit_ICU_ptr[d*np+i]; }
-                    if (exit_vent_ptr[d*np+i] > 0) { released_from_vent_ptr[i] *= exit_vent_ptr[d*np+i]; }
+                    if (exit_hosp_ptr[d*np+i] > 0) { rm_from_hosp_ptr[i] *= exit_hosp_ptr[d*np+i]; count_h++; }
+                    if (exit_ICU_ptr[d*np+i] > 0)  { rm_from_ICU_ptr[i] *= exit_ICU_ptr[d*np+i]; count_i++; }
+                    if (exit_vent_ptr[d*np+i] > 0) { rm_from_vent_ptr[i] *= exit_vent_ptr[d*np+i]; count_v++; }
                 }
+                if (count_h == 0) { rm_from_hosp_ptr[i] = 0; }
+                if (count_i == 0) { rm_from_ICU_ptr[i] = 0; }
+                if (count_v == 0) { rm_from_vent_ptr[i] = 0; }
 
                 if (is_alive_ptr[i] == 0) {
                     // agent has died
@@ -242,7 +248,7 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                         p.pos(0) = static_cast<ParticleReal>((home_i_ptr[i] + 0.5_rt) * dx[0]);
                         p.pos(1) = static_cast<ParticleReal>((home_j_ptr[i] + 0.5_rt) * dx[1]);
                     } else {
-                      AMREX_ALWAYS_ASSERT(!released_from_hosp_ptr[i]);
+                      AMREX_ALWAYS_ASSERT(!rm_from_hosp_ptr[i]);
                     }
                 }
             });
@@ -255,13 +261,13 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                     if (flag_status_ptr[i] < 0) {
                         Gpu::Atomic::AddNoRet(&ds_arr(home_i_ptr[i], home_j_ptr[i], 0, DiseaseStats::death), 1.0_rt);
                     }
-                    if (released_from_hosp_ptr[i]) {
+                    if (rm_from_hosp_ptr[i]) {
                         Gpu::Atomic::AddNoRet(&ds_arr(home_i_ptr[i], home_j_ptr[i], 0, DiseaseStats::hospitalization), -1.0_rt);
                     }
-                    if (released_from_ICU_ptr[i]) {
+                    if (rm_from_ICU_ptr[i]) {
                         Gpu::Atomic::AddNoRet(&ds_arr(home_i_ptr[i], home_j_ptr[i], 0, DiseaseStats::ICU), -1.0_rt);
                     }
-                    if (released_from_vent_ptr[i]) {
+                    if (rm_from_vent_ptr[i]) {
                         Gpu::Atomic::AddNoRet(&ds_arr(home_i_ptr[i], home_j_ptr[i], 0, DiseaseStats::ventilator), -1.0_rt);
                     }
                 });

--- a/src/HospitalModel.H
+++ b/src/HospitalModel.H
@@ -96,9 +96,9 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
             Gpu::DeviceVector<int> flag_status(np);
             auto flag_status_ptr = flag_status.data();
 
-            Gpu::DeviceVector<int> exit_hosp(np*n_disease, 1);
-            Gpu::DeviceVector<int> exit_ICU(np*n_disease, 1);
-            Gpu::DeviceVector<int> exit_vent(np*n_disease, 1);
+            Gpu::DeviceVector<int> exit_hosp(np*n_disease, -1);
+            Gpu::DeviceVector<int> exit_ICU(np*n_disease, -1);
+            Gpu::DeviceVector<int> exit_vent(np*n_disease, -1);
             auto exit_hosp_ptr = exit_hosp.data();
             auto exit_ICU_ptr  = exit_ICU.data();
             auto exit_vent_ptr = exit_vent.data();
@@ -130,34 +130,42 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                 ParallelForRNG(np, [=] AMREX_GPU_DEVICE (int i, RandomEngine const& engine) noexcept {
                     if (!inHospital(i, ptd)) {
                         // agent is not in hospital
-                        exit_hosp_ptr[d*np+i] = 0;
-                        exit_ICU_ptr[d*np+i] = 0;
-                        exit_vent_ptr[d*np+i] = 0;
                         return;
                     }
                     if (counter_ptrs[d][i] == Math::floor(incubation_per_ptrs[d][i]) + Math::floor(hospital_delay_ptrs[d][i])) {
                         // agent just started treatment
-                        exit_hosp_ptr[d*np+i] = 0;
-                        exit_ICU_ptr[d*np+i] = 0;
-                        exit_vent_ptr[d*np+i] = 0;
                         return;
                     }
                     if (timer_ptrs[d][i] == 0) {
                         // agent has recovered/died from disease d
-                        exit_hosp_ptr[d*np+i] = 0;
-                        exit_ICU_ptr[d*np+i] = 0;
-                        exit_vent_ptr[d*np+i] = 0;
                         return;
                     }
                     if (is_alive_ptr[i] == 0) {
                         // agent is dead
-                        exit_hosp_ptr[d*np+i] = 0;
-                        exit_ICU_ptr[d*np+i] = 0;
-                        exit_vent_ptr[d*np+i] = 0;
                         return;
                     }
 
                     AMREX_ALWAYS_ASSERT(status_ptrs[d][i] == Status::infected);
+                    // check for exit conditions
+                    if (timer_ptrs[d][i] > 2 * disease_parm_d->m_t_hosp_offset + 1) {
+                        exit_vent_ptr[d*np+i] = 0;
+                        exit_ICU_ptr[d*np+i] = 0;
+                        exit_hosp_ptr[d*np+i] = 0;
+                    } else if (timer_ptrs[d][i] == 2 * disease_parm_d->m_t_hosp_offset + 1) {
+                        exit_vent_ptr[d*np+i] = 1;
+                        exit_ICU_ptr[d*np+i] = 1;
+                        exit_hosp_ptr[d*np+i] = 1;
+                    } else if (timer_ptrs[d][i] > disease_parm_d->m_t_hosp_offset + 1) {
+                        exit_ICU_ptr[d*np+i] = 0;
+                        exit_hosp_ptr[d*np+i] = 0;
+                    } else if (timer_ptrs[d][i] == disease_parm_d->m_t_hosp_offset + 1) {
+                        exit_ICU_ptr[d*np+i] = 1;
+                        exit_hosp_ptr[d*np+i] = 1;
+                    } else if (timer_ptrs[d][i] > 1) {
+                        exit_hosp_ptr[d*np+i] = 0;
+                    } else if (timer_ptrs[d][i] == 1) {
+                        exit_hosp_ptr[d*np+i] = 1;
+                    }
                     // decrement days in hospital
                     timer_ptrs[d][i] -= 1.0_prt;
                     if (timer_ptrs[d][i] == 0) {
@@ -169,16 +177,6 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                     } else if (timer_ptrs[d][i] == 2 * disease_parm_d->m_t_hosp_offset) {
                         // finished ventilator hospitalization period, counted down to 2 * m_t_hosp_offset
                         flag_status_ptr[i] = DiseaseStats::ventilator + 1;
-                    }
-                    // check for exit conditions
-                    if (timer_ptrs[d][i] != 2 * disease_parm_d->m_t_hosp_offset) {
-                        exit_vent_ptr[d*np+i] = 0;
-                    }
-                    if (timer_ptrs[d][i] != disease_parm_d->m_t_hosp_offset) {
-                        exit_ICU_ptr[d*np+i] = 0;
-                    }
-                    if (timer_ptrs[d][i] != 0) {
-                        exit_hosp_ptr[d*np+i] = 0;
                     }
 
                     if (flag_status_ptr[i] > 0) {
@@ -216,9 +214,9 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                 released_from_ICU_ptr[i] = 1;
                 released_from_vent_ptr[i] = 1;
                 for (int d = 0; d < n_disease; d++) {
-                    released_from_hosp_ptr[i] *= exit_hosp_ptr[d*np+i];
-                    released_from_ICU_ptr[i] *= exit_ICU_ptr[d*np+i];
-                    released_from_vent_ptr[i] *= exit_vent_ptr[d*np+i];
+                    if (exit_hosp_ptr[d*np+i] > 0) { released_from_hosp_ptr[i] *= exit_hosp_ptr[d*np+i]; }
+                    if (exit_ICU_ptr[d*np+i] > 0)  { released_from_ICU_ptr[i] *= exit_ICU_ptr[d*np+i]; }
+                    if (exit_vent_ptr[d*np+i] > 0) { released_from_vent_ptr[i] *= exit_vent_ptr[d*np+i]; }
                 }
 
                 if (is_alive_ptr[i] == 0) {

--- a/src/HospitalModel.H
+++ b/src/HospitalModel.H
@@ -234,13 +234,13 @@ void HospitalModel<PCType, PTDType, PType>::treatAgents (PCType& a_agents, /*!< 
                     if (flag_status_ptr[i] < 0) {
                         Gpu::Atomic::AddNoRet(&ds_arr(home_i_ptr[i], home_j_ptr[i], 0, DiseaseStats::death), 1.0_rt);
                     }
-                    if (released_from_hosp[i]) {
+                    if (released_from_hosp_ptr[i]) {
                         Gpu::Atomic::AddNoRet(&ds_arr(home_i_ptr[i], home_j_ptr[i], 0, DiseaseStats::hospitalization), -1.0_rt);
                     }
-                    if (released_from_ICU[i]) {
+                    if (released_from_ICU_ptr[i]) {
                         Gpu::Atomic::AddNoRet(&ds_arr(home_i_ptr[i], home_j_ptr[i], 0, DiseaseStats::ICU), -1.0_rt);
                     }
-                    if (released_from_vent[i]) {
+                    if (released_from_vent_ptr[i]) {
                         Gpu::Atomic::AddNoRet(&ds_arr(home_i_ptr[i], home_j_ptr[i], 0, DiseaseStats::ventilator), -1.0_rt);
                     }
                 });

--- a/src/IO.cpp
+++ b/src/IO.cpp
@@ -373,7 +373,7 @@ void writeFIPSData (const AgentContainer& agents,                  /*!< Agents (
                     auto bx = mfi.tilebox();
                     amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                         int unit = unit_arr(i, j, k); // which FIPS
-                        int num_infected = int(cell_data_arr(i, j, k, 2));
+                        int num_infected = int(cell_data_arr(i, j, k, 5*d+2));
                         amrex::Gpu::Atomic::AddNoRet(&data_ptr[unit], (amrex::Real)num_infected);
                     });
                 }
@@ -452,7 +452,7 @@ void writeAggregatedData (const AgentContainer& agents,                  /*!< Ag
                     amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                         int block_group_i = block_group_indices_arr(i, j, k);
                         if (block_group_i == -1) { return; }
-                        int num_infected = int(cell_data_arr(i, j, k, 2));
+                        int num_infected = int(cell_data_arr(i, j, k, 5*d+2));
                         // This should not require an atomic operation because each block group is at a separate i,j location
                         // amrex::Gpu::Atomic::AddNoRet(&data_ptr[block_group_i], (amrex::Real)num_infected);
                         data_ptr[block_group_i] = (amrex::Real)num_infected;

--- a/src/IO.cpp
+++ b/src/IO.cpp
@@ -373,7 +373,7 @@ void writeFIPSData (const AgentContainer& agents,                  /*!< Agents (
                     auto bx = mfi.tilebox();
                     amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                         int unit = unit_arr(i, j, k); // which FIPS
-                        int num_infected = int(cell_data_arr(i, j, k, 5*d+2));
+                        int num_infected = int(cell_data_arr(i, j, k, 5 * d + 2));
                         amrex::Gpu::Atomic::AddNoRet(&data_ptr[unit], (amrex::Real)num_infected);
                     });
                 }
@@ -452,7 +452,7 @@ void writeAggregatedData (const AgentContainer& agents,                  /*!< Ag
                     amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                         int block_group_i = block_group_indices_arr(i, j, k);
                         if (block_group_i == -1) { return; }
-                        int num_infected = int(cell_data_arr(i, j, k, 5*d+2));
+                        int num_infected = int(cell_data_arr(i, j, k, 5 * d + 2));
                         // This should not require an atomic operation because each block group is at a separate i,j location
                         // amrex::Gpu::Atomic::AddNoRet(&data_ptr[block_group_i], (amrex::Real)num_infected);
                         data_ptr[block_group_i] = (amrex::Real)num_infected;


### PR DESCRIPTION
## Summary

Fixes assertion failures (`mmc[1] >= 0`, `mmc[2] >= 0`) in multi-disease runs caused by inconsistent hospitalization statistics tracking.

### Root causes

1. **Shared `flag_status_ptr` in `HospitalModel.H`**: The hospital status flag was agent-level but modified inside a per-disease loop. A later disease could overwrite the flag set by an earlier disease, causing spurious death/recovery checks and incorrect stats decrements.

2. **Shared `marked_for_ICU/vent` in `DiseaseStatus.H`**: `checkHospitalization()` reset ICU and ventilator flags to 0 at the start, so a later disease could undo an earlier disease's ICU/vent assignment. This caused missing increments while the corresponding decrements still occurred via per-disease treatment timers, driving counts negative.

### Fix

**`HospitalModel.H`**:
- Replace the shared `flag_status_ptr` with per-disease exit tracking arrays (`exit_hosp`, `exit_ICU`, `exit_vent`) of size `np * n_disease`, initialized to `-1` (no opinion).
- Before each timer decrement, each disease independently records whether the agent should exit each hospital level (`0` = not yet, `1` = ready to exit) based on its pre-decrement timer value.
- Use a local `status_d` for death/recovery checks so diseases don't interfere with each other.
- Track deaths via a separate `died_today` flag instead of encoding in `flag_status_ptr`.
- After all diseases are processed, compute agent-level release flags (`rm_from_hosp/ICU/vent`) as the product across all diseases that have an opinion — the agent only exits a level when **all** active diseases agree.
- Stats decrements use these agent-level release flags, ensuring they fire exactly once per hospital entry.

**`DiseaseParm.H`**:
- Remove the `*a_ICU = 0; *a_ventilator = 0;` resets at the start of `checkHospitalization()`, so a later disease cannot overwrite an earlier disease's ICU/vent assignment.

## Test plan
- [x] Run single-disease cases to verify no regression (stats should be identical)
- [x] Run multi-disease cases (e.g., `bay_02D_Cov19S1_FluS1`) to verify no assertion failures and runs complete to `nsteps`
- [x] Verify ICU/ventilator/hospitalization counts remain non-negative throughout simulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)