### PR TITLE
Fix worker assignment bug causing phantom transcontinental commutes

### DIFF
--- a/src/CensusData.cpp
+++ b/src/CensusData.cpp
@@ -550,7 +550,7 @@ void CensusData::readWorkerflow (AgentContainer& pc, /*!< Agent container (parti
             /* Check working-age population */
             if (age_group >= AgeGroups::a18to29 && age_group <= AgeGroups::a50to64) {
                 unsigned int irnd = Random_int(nwork, engine);
-                int to = from;  // Default: work in home unit
+                int to = from; // Default: work in home unit
                 int comm_to = 0;
                 if (irnd < d_flow[from][Nunit - 1]) {
                     /* Choose a random destination unit */

--- a/src/CensusData.cpp
+++ b/src/CensusData.cpp
@@ -550,7 +550,7 @@ void CensusData::readWorkerflow (AgentContainer& pc, /*!< Agent container (parti
             /* Check working-age population */
             if (age_group >= AgeGroups::a18to29 && age_group <= AgeGroups::a50to64) {
                 unsigned int irnd = Random_int(nwork, engine);
-                int to = 0;
+                int to = from;  // Default: work in home unit
                 int comm_to = 0;
                 if (irnd < d_flow[from][Nunit - 1]) {
                     /* Choose a random destination unit */
@@ -559,6 +559,7 @@ void CensusData::readWorkerflow (AgentContainer& pc, /*!< Agent container (parti
                         to++;
                     }
                 }
+                // else: irnd >= d_flow[from][Nunit - 1], stay in home unit (to = from)
 
                 /*If from=to unit, 25% EXTRA chance of working in home community*/
                 if ((from == to) && (Random(engine) < 0.25)) {


### PR DESCRIPTION
**Fix worker assignment bug** (`CensusData.cpp`): When `irnd >= d_flow[from][Nunit - 1]`, workers defaulted to unit 0 instead of their home unit, causing phantom transcontinental commutes and unrealistic nationwide disease spread in a single day. Changed `int to = 0` to `int to = from`.

Before the fix, initial cases seeded in one geographic location seemed to spread throughout the US even without any travel:
<img width="1521" height="643" alt="infections_US_01D_FluS1_perlmutter_day00000" src="https://github.com/user-attachments/assets/f7ba307d-0334-4412-ab48-1d662f834723" />
<img width="1521" height="643" alt="infections_US_01D_FluS1_perlmutter_day00001" src="https://github.com/user-attachments/assets/57c9afee-c3f1-4ae2-a60d-151859439542" />

After the fix, cases spread based on worker commutes:
<img width="1521" height="643" alt="infections_US_01D_FluS1_dane_day00000" src="https://github.com/user-attachments/assets/6018e647-8578-481e-8df4-cd727c21c1df" />
<img width="1521" height="643" alt="infections_US_01D_FluS1_dane_day00001" src="https://github.com/user-attachments/assets/1c38bbfb-d057-4a6e-8951-0cae413e8c92" />
<img width="1521" height="643" alt="infections_US_01D_FluS1_dane_day00002" src="https://github.com/user-attachments/assets/adc463d3-699c-43f0-b156-af120bb84527" />
<img width="1521" height="643" alt="infections_US_01D_FluS1_dane_day00003" src="https://github.com/user-attachments/assets/8ac9a21c-cab6-4fc3-b9e8-e3a113b5b251" />


**This changes the solution significantly**: Simulations for Bay Area and CA shown below:
<img width="1966" height="1420" alt="ca tuolumne" src="https://github.com/user-attachments/assets/068230f8-3f2c-43af-b397-79bfb7005abf" />

<img width="1946" height="1420" alt="bay tuolumne" src="https://github.com/user-attachments/assets/09e3b2dc-172e-40ce-8537-b80677fb3199" />
