### PR TITLE
Fix Some bugs in random and air travel

### DIFF
--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -209,7 +209,7 @@ void AgentContainer::moveAgentsToWork () {
             auto work_j_ptr = soa.GetIntData(IntIdx::work_j).data();
 
             amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE (int ip) noexcept {
-                if (!inHospital(ip, ptd)) {
+                if (!inHospital(ip, ptd) && !isOnTravel(ip, ptd)) {
                     ParticleType& p = pstruct[ip];
                     p.pos(0) = static_cast<ParticleReal>((work_i_ptr[ip] + 0.5_rt) * dx[0]);
                     p.pos(1) = static_cast<ParticleReal>((work_j_ptr[ip] + 0.5_rt) * dx[1]);
@@ -252,7 +252,7 @@ void AgentContainer::moveAgentsToHome () {
             auto home_j_ptr = soa.GetIntData(IntIdx::home_j).data();
 
             amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE (int ip) noexcept {
-                if (!inHospital(ip, ptd)) {
+                if (!inHospital(ip, ptd) && !isOnTravel(ip, ptd)) {
                     ParticleType& p = pstruct[ip];
                     p.pos(0) = static_cast<ParticleReal>((home_i_ptr[ip] + 0.5_rt) * dx[0]);
                     p.pos(1) = static_cast<ParticleReal>((home_j_ptr[ip] + 0.5_rt) * dx[1]);

--- a/src/AgentContainer.cpp
+++ b/src/AgentContainer.cpp
@@ -424,7 +424,7 @@ void AgentContainer::setAirTravel (const iMultiFab& unit_mf, AirTravelFlow& air,
                         }
                     } else {           // binary search algorithm
                         while (low < high) {
-                            if (random1 < low) {
+                            if (random1 < arrivalUnits_prob_ptr[low]) {
                                 break; // low is the found airport index
                             }
                             // if random1 falls within (low, high), half the range
@@ -432,12 +432,12 @@ void AgentContainer::setAirTravel (const iMultiFab& unit_mf, AirTravelFlow& air,
                             if (arrivalUnits_prob_ptr[mid] < random1) {
                                 low = mid + 1;
                             } else {
-                                high = mid - 1;
+                                high = mid;
                             }
                         }
                         destUnit = arrivalUnits_ptr[low];
                     }
-                    if (destUnit >= 0) {
+                    if (destUnit >= 0 && (Start[destUnit + 1] > Start[destUnit])) { // skip size 0 comms
                         // randomly select a community in the dest unit
                         int comm_to = Start[destUnit] + amrex::Random_int(Start[destUnit + 1] - Start[destUnit], engine);
                         int new_i = comm_to % i_max;

--- a/src/AgentDefinitions.H
+++ b/src/AgentDefinitions.H
@@ -223,6 +223,14 @@ bool isNewlySymptomatic (const int a_idx,      /*!< Agent index */
     return status == Status::infected && disease_counter == incb_period && symptom_status == SymptomStatus::symptomatic;
 }
 
+/*! \brief Is agent on travel? */
+template <typename PTDType>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+bool isOnTravel (const int a_idx, /*!< Agent index */
+                 const PTDType& a_ptd /*!< Particle tile data */) {
+    return (a_ptd.m_idata[IntIdx::random_travel][a_idx] >= 0 || a_ptd.m_idata[IntIdx::air_travel][a_idx] >= 0);
+}
+
 /*! \brief Did the agent just become asymptomatic this step? */
 template <typename PTDType>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE


### PR DESCRIPTION
The first bug is we need to skip agents on travel during the daily commutes. The order of operations is:

1) move agents to irregular locations.
2) move agents to daytime locations.
3) move agents to nighttime locations.
4) return agents from irregular locations.

So if we don't skip them the positions are overwritten and the travel has no effect. 

The second bug involves a comparison the binary search. A random number draw was being compared to an index, it needs to be compared to the associated probability.

Third, the binary search was incorrectly ruling out the `mid` point in the case that it took the `high` branch.

Finally, we need to skip size zero communities at the end because `amrex::Random_int(0, engine)` is currently undefined behavior. We may change this in AMReX but for now this is needed.

