### PR TITLE
Bump CI GCC matrix to >= 11 (AMReX minimum)

### DIFF
--- a/.github/workflows/dependencies/dependencies.sh
+++ b/.github/workflows/dependencies/dependencies.sh
@@ -7,11 +7,12 @@
 
 set -eu -o pipefail
 
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt-get update
 
 sudo apt-get install -y --no-install-recommends\
-    build-essential \
-    g++ gfortran    \
-    libopenmpi-dev  \
-    openmpi-bin     \
+    build-essential    \
+    g++-12 gfortran-12 \
+    libopenmpi-dev     \
+    openmpi-bin        \
     libhdf5-openmpi-dev

--- a/.github/workflows/dependencies/dependencies_gcc10.sh
+++ b/.github/workflows/dependencies/dependencies_gcc10.sh
@@ -12,7 +12,7 @@ sudo apt-get update
 
 sudo apt-get install -y --no-install-recommends \
     build-essential    \
-    g++-10 gfortran-10 \
+    g++-13 gfortran-13 \
     libopenmpi-dev     \
     openmpi-bin        \
     libhdf5-openmpi-dev

--- a/.github/workflows/dependencies/dependencies_gcc8.sh
+++ b/.github/workflows/dependencies/dependencies_gcc8.sh
@@ -10,20 +10,9 @@ set -eu -o pipefail
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt-get update
 
-sudo cat <<EOF | sudo tee /etc/apt/sources.list.d/gcc-8.list
-deb http://old-releases.ubuntu.com/ubuntu/ impish main restricted universe multiverse
-EOF
-
-sudo apt update
-apt-cache policy g++-8
-apt-cache show g++-8
-sudo apt install g++-8
-apt-cache policy gfortran-8
-apt-cache show gfortran-8
-sudo apt install gfortran-8
-
 sudo apt-get install -y --no-install-recommends \
     build-essential    \
+    g++-11 gfortran-11 \
     libopenmpi-dev     \
     openmpi-bin        \
     libhdf5-openmpi-dev

--- a/.github/workflows/dependencies/dependencies_gcc8_nompi.sh
+++ b/.github/workflows/dependencies/dependencies_gcc8_nompi.sh
@@ -10,20 +10,9 @@ set -eu -o pipefail
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt-get update
 
-sudo cat <<EOF | sudo tee /etc/apt/sources.list.d/gcc-8.list
-deb http://old-releases.ubuntu.com/ubuntu/ impish main restricted universe multiverse
-EOF
-
-sudo apt update
-apt-cache policy g++-8
-apt-cache show g++-8
-sudo apt install g++-8
-apt-cache policy gfortran-8
-apt-cache show gfortran-8
-sudo apt install gfortran-8
-
 sudo apt-get install -y --no-install-recommends \
     build-essential    \
+    g++-11 gfortran-11 \
     libopenmpi-dev     \
     openmpi-bin        \
     libhdf5-dev

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -13,7 +13,7 @@ jobs:
   # Build ExaEpi
   # Note: this is an intentional "minimal" build that does not enable (many) options
   library:
-    name: GNU@8.4 C++17 Release
+    name: GNU@11 C++17 Release
     runs-on: ubuntu-24.04
     env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs -Wno-unused-parameter"}
     steps:
@@ -26,14 +26,14 @@ jobs:
         cd build
         cmake ..                                  \
             -DCMAKE_VERBOSE_MAKEFILE=ON           \
-            -DCMAKE_C_COMPILER=$(which gcc-8)     \
-            -DCMAKE_CXX_COMPILER=$(which g++-8)   \
-            -DCMAKE_Fortran_COMPILER=$(which gfortran-8)
+            -DCMAKE_C_COMPILER=$(which gcc-11)     \
+            -DCMAKE_CXX_COMPILER=$(which g++-11)   \
+            -DCMAKE_Fortran_COMPILER=$(which gfortran-11)
         make -j 2
 
   # Build ExaEpi [Debug]
   build_debug:
-    name: GNU@9.3 C++17 Debug
+    name: GNU@12 C++17 Debug
     runs-on: ubuntu-24.04
     env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -O1 -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs -Wno-unused-parameter"}
       # It's too slow with -O0
@@ -45,7 +45,10 @@ jobs:
       run: |
         cmake -S . -B build             \
             -DCMAKE_BUILD_TYPE=Debug    \
-            -DCMAKE_VERBOSE_MAKEFILE=ON
+            -DCMAKE_VERBOSE_MAKEFILE=ON \
+            -DCMAKE_C_COMPILER=$(which gcc-12)     \
+            -DCMAKE_CXX_COMPILER=$(which g++-12)   \
+            -DCMAKE_Fortran_COMPILER=$(which gfortran-12)
         cmake --build build -j 2
     - name: Run Tests
       run: |
@@ -53,7 +56,7 @@ jobs:
 
   # Build ExaEpi
   tests_cxx20:
-    name: GNU@10.1 C++20 OMP
+    name: GNU@13 C++20 OMP
     runs-on: ubuntu-24.04
     env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs -Wno-unused-parameter"}
     steps:
@@ -73,9 +76,9 @@ jobs:
             -DAMReX_FPE=ON              \
             -DAMReX_OMP=ON              \
             -DCMAKE_CXX_STANDARD=20     \
-            -DCMAKE_C_COMPILER=$(which gcc-10)              \
-            -DCMAKE_CXX_COMPILER=$(which g++-10)            \
-            -DCMAKE_Fortran_COMPILER=$(which gfortran-10)
+            -DCMAKE_C_COMPILER=$(which gcc-13)              \
+            -DCMAKE_CXX_COMPILER=$(which g++-13)            \
+            -DCMAKE_Fortran_COMPILER=$(which gfortran-13)
         make -j 2
     - name: Run Tests
       run: |
@@ -83,7 +86,7 @@ jobs:
 
   # Build ExaEpi w/o MPI
   tests-nonmpi:
-    name: GNU@8.4 C++17 NOMPI
+    name: GNU@11 C++17 NOMPI
     runs-on: ubuntu-24.04
     env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs -Wno-unused-parameter"}
     steps:
@@ -102,7 +105,7 @@ jobs:
             -DAMReX_BOUND_CHECK=ON      \
             -DAMReX_FPE=ON              \
             -DAMReX_MPI=OFF             \
-            -DCMAKE_C_COMPILER=$(which gcc-8)     \
-            -DCMAKE_CXX_COMPILER=$(which g++-8)   \
-            -DCMAKE_Fortran_COMPILER=$(which gfortran-8)
+            -DCMAKE_C_COMPILER=$(which gcc-11)     \
+            -DCMAKE_CXX_COMPILER=$(which g++-11)   \
+            -DCMAKE_Fortran_COMPILER=$(which gfortran-11)
         make -j 2


### PR DESCRIPTION
## Problem

ExaEpi's CMake fetches AMReX's `development` branch, which now requires GCC >= 11. The `Linux GCC` workflow still pins older compilers, so the GNU 8.4/9.3/10.1 jobs fail at CMake configure with:

```
GNU compiler version is X. Minimum required is 11.0.
```

This is a toolchain-version issue, not a source-code issue.

## Fix

Bump the GCC matrix from 8.4/9.3/10.1 to 11/12/13. All three are installable via apt on the `ubuntu-24.04` runner.

- 8.4 -> 11 (Release, NOMPI)
- 9.3 -> 12 (Debug)
- 10.1 -> 13 (C++20 OMP)

Each job keeps its other attributes (MPI/NOMPI, Debug/Release, C++ standard, OMP).

## Changes

- `.github/workflows/gcc.yml`: job `name:` strings and the explicit `CMAKE_*_COMPILER` flags.
- `.github/workflows/dependencies/dependencies.sh`, `dependencies_gcc8.sh`, `dependencies_gcc8_nompi.sh`, `dependencies_gcc10.sh`: apt package names.
- The `old-releases` apt source in the former gcc-8 scripts is removed; it was only needed to obtain gcc-8, which is not packaged on Ubuntu 24.04.

No source files or other workflows are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
