### PR TITLE
Reference-normalize weather transmission scale factor (AH_ref + clamp)

### DIFF
--- a/docs/source/usage/how_to_run.rst
+++ b/docs/source/usage/how_to_run.rst
@@ -271,12 +271,14 @@ humidity :math:`AH` (g/m³):
 
 .. math::
 
-   p(T,AH) = p_max exp(-beta_AH * AH - alpha_T * \max(0,T - T_0))
+   p(T,AH) = \min\left(1,\; p_max \exp(-beta_AH (AH - AH_{ref}) - alpha_T \max(0,T - T_0))\right)
 
 * ``weather_transmission.p_max`` (`float`, default ``1.0``)
-    Maximum transmission scale factor (dimensionless).  At low temperature and low humidity the
-    scale factor approaches this value.  It is multiplied by the baseline transmission probability
-    ``disease.p_trans`` to give the effective transmission probability.
+    Maximum transmission scale factor (dimensionless).  The scale factor is multiplied by the
+    baseline transmission probability ``disease.p_trans`` to give the effective transmission
+    probability, and the result is clamped to 1.  With ``p_max = 1`` the scale factor equals 1
+    at/below ``AH_ref`` (and ``T <= T0``), so the calibrated baseline ``disease.p_trans`` is
+    recovered during flu-season conditions; warmer/more humid conditions reduce it.
 * ``weather_transmission.beta_AH`` (`float`, default ``0.18``)
     Absolute-humidity sensitivity coefficient in units of m³/g.  Larger values cause transmission
     to decrease more rapidly as humidity increases.
@@ -286,6 +288,11 @@ humidity :math:`AH` (g/m³):
 * ``weather_transmission.alpha_T`` (`float`, default ``0.015``)
     Temperature sensitivity coefficient in units of °C⁻¹.  Larger values cause transmission
     to decrease more rapidly above ``T0``.
+* ``weather_transmission.AH_ref`` (`float`, default ``6.0``)
+    Reference absolute humidity in g/m³ at which the (unclamped) scale factor equals ``p_max``.
+    Choose it near the flu-season absolute humidity so that the calibrated ``disease.p_trans`` is
+    preserved during the epidemic season rather than being suppressed everywhere.  Set to ``0.0``
+    to recover the un-normalised ``AH = 0`` reference.
 
 In addition to the ExaEpi inputs, there are also a number of runtime options that can be configured for AMReX itself.
 Please see <https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters>`__ for more information on these options.

--- a/examples/inputs_random_us_weather
+++ b/examples/inputs_random_us_weather
@@ -13,6 +13,8 @@ agent.do_weather = 1
 agent.weather_filename = "/global/homes/a/atmyers/ExaEpi/data/weatherData_US.csv"
 agent.startdate="2018-1-1"
 
+# weather_transmission.AH_ref = 6.0   # AH (g/m^3) at which the weather scale = 1 (flu-season ref)
+
 agent.aggregated_diag_int = -1
 
 disease.initial_case_type = "random"

--- a/src/WeatherTransmissionModel.H
+++ b/src/WeatherTransmissionModel.H
@@ -16,16 +16,23 @@
 
 /*! \brief Weather-dependent transmission probability model.
  *
- *  Computes the transmission probability as a function of near-surface air
- *  temperature and absolute humidity:
+ *  Computes a weather-based scale factor for the transmission probability as a
+ *  function of near-surface air temperature and absolute humidity:
  *
  *  \f[
- *    p(T,AH) = p_max exp(-beta_AH * AH - alpha_T * \max(0,T - T_0))
+ *    p(T,AH) = \min\left(1,\; p_max \exp(-beta_AH (AH - AH_{ref}) - alpha_T \max(0,T - T_0))\right)
  *  \f]
  *
  *  where \f$T\f$ is temperature in degrees Celsius and \f$AH\f$ is absolute
- *  humidity in g/m^3.  The compute function (#operator()) is decorated with
- *  AMREX_GPU_HOST_DEVICE so it may be called from within amrex::ParallelFor
+ *  humidity in g/m^3.  The exponential is referenced at \f$AH_{ref}\f$ (rather
+ *  than at \f$AH=0\f$, which is never reached in practice): with \c p_max = 1
+ *  the scale factor equals 1 at/below \f$AH_{ref}\f$ and \f$T \le T_0\f$, so the
+ *  calibrated baseline transmission probability is recovered during flu-season
+ *  conditions and weather only attenuates it toward summer.  The result is
+ *  clamped to 1 so that \f$1 - infect \cdot xmit \cdot p \ge 0\f$ always holds
+ *  (the value is used as a multiplier on the baseline \c disease.p_trans /
+ *  \c xmit_* probabilities).  The compute function (#operator()) is decorated
+ *  with AMREX_GPU_HOST_DEVICE so it may be called from within amrex::ParallelFor
  *  kernels on both CPU and GPU backends.
  *
  *  Parameters are parsed from the inputs file under the prefix supplied to
@@ -36,6 +43,9 @@
  *  | \c weather_transmission.beta_AH | 0.18    | m^3/g       |
  *  | \c weather_transmission.T0      | 5.0     | °C          |
  *  | \c weather_transmission.alpha_T | 0.015   | °C^{-1}     |
+ *  | \c weather_transmission.AH_ref  | 6.0     | g/m^3       |
+ *
+ *  Set \c AH_ref = 0 (with \c p_max = 1) to recover the un-normalised behaviour.
  */
 struct WeatherTransmissionModel {
 
@@ -52,6 +62,13 @@ struct WeatherTransmissionModel {
     /*! Temperature sensitivity coefficient (°C^{-1}).
      *  Higher values make transmission drop faster above T0. */
     amrex::Real alpha_T = amrex::Real(0.015);
+
+    /*! Reference absolute humidity (g/m^3) at which the weather scale factor
+     *  equals p_max (i.e. the clamped scale factor is 1 for p_max = 1 when
+     *  T <= T0).  Set this near the flu-season AH so the calibrated baseline
+     *  transmission probability is recovered during the epidemic season.
+     *  Set to 0 to recover the un-normalised AH=0 reference. */
+    amrex::Real AH_ref = amrex::Real(6.0);
 
     /*! \brief Parse model parameters from the AMReX inputs file.
      *
@@ -70,12 +87,13 @@ struct WeatherTransmissionModel {
      *
      *  \param T_celsius    Near-surface air temperature (°C).
      *  \param AH_g_per_m3  Absolute humidity (g/m^3).
-     *  \return             Transmission probability \f$p(T,AH)\f$.
+     *  \return             Weather transmission scale factor \f$p(T,AH) \in (0,1]\f$.
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     amrex::Real operator()(amrex::Real T_celsius, amrex::Real AH_g_per_m3) const noexcept {
         amrex::Real T_excess = amrex::max(amrex::Real(0), T_celsius - T0);
-        return p_max * std::exp(-beta_AH * AH_g_per_m3 - alpha_T * T_excess);
+        amrex::Real rho = p_max * std::exp(-beta_AH * (AH_g_per_m3 - AH_ref) - alpha_T * T_excess);
+        return amrex::min(amrex::Real(1), rho);   // rho <= 1 keeps 1 - infect*xmit*rho >= 0
     }
 
     /*! \brief Evaluate the transmission probability directly from a #weatherVars record.

--- a/src/WeatherTransmissionModel.cpp
+++ b/src/WeatherTransmissionModel.cpp
@@ -13,4 +13,5 @@ void WeatherTransmissionModel::readInputs (const std::string& pp_str) {
     pp.query("beta_AH", beta_AH);
     pp.query("T0", T0);
     pp.query("alpha_T", alpha_T);
+    pp.query("AH_ref", AH_ref);
 }


### PR DESCRIPTION
## Summary

Refinement to the weather-dependent transmission model added in #150. The model

```
rho(T,AH) = p_max * exp(-beta_AH*AH - alpha_T*max(0,T-T0))
```

references the absolute-humidity exponential at `AH = 0`, which never occurs in the data (US min 0.13, p05 2.9 g/m³). So `rho` is far below 1 everywhere — **US mean ≈ 0.20, even peak winter only ≈ 0.38**. Since `rho` multiplies the calibrated baseline transmission probabilities (`disease.p_trans` / `xmit_*`) via `prob = 1 - infect*xmit*rho`, turning the weather model on **suppresses effective transmission ~5× year-round** and craters the calibrated R0.

## Change

Move the exponential's reference point to a flu-season absolute humidity `AH_ref` (default **6.0 g/m³**) and clamp the result to 1:

```
rho = min(1, p_max * exp(-beta_AH*(AH - AH_ref) - alpha_T*max(0,T-T0)))
```

With `p_max = 1` the scale factor is 1 at/below `AH_ref` (and `T <= T0`), so the calibrated baseline is recovered during flu-season conditions and weather only attenuates toward summer. The clamp keeps `1 - infect*xmit*rho >= 0`. Set `AH_ref = 0` to recover the previous behaviour.

The model *form* (exponential decay in AH, `T0 ~ 5 °C` threshold) is unchanged and remains supported by Shaman & Kohn 2009, Peci et al. 2019, Park et al. 2020, and Lowen et al. 2007 — only the normalisation changes.

## Verification

- **rho over `weatherData_US.csv`** (AH_ref=6, defaults): mean 0.47, winter (DJF) 0.81, summer (JJA) 0.13 (~6.3× swing), 22% of county-weeks at rho=1. Clamp invariant holds (max rho = 1, so `1 - infect*xmit*rho >= 0`).
- **120-day MA simulation** (`inputs.ma`, built locally):

  | Run | Total infections | Final deaths |
  |---|---|---|
  | `do_weather=0` (baseline) | 141,396 | 3,786 |
  | `AH_ref=6` (new default) | 141,274 | 3,786 |
  | `AH_ref=0` (old behaviour) | 42,225 | 1,323 |

  The new default reproduces the calibrated epidemic (winter-seeded outbreak burns through while rho≈1), whereas the old un-normalised reference suppressed it to ~30%.

## Files

- `src/WeatherTransmissionModel.H` — `AH_ref` member + normalised/clamped compute, doc update
- `src/WeatherTransmissionModel.cpp` — parse `weather_transmission.AH_ref`
- `docs/source/usage/how_to_run.rst` — formula + `AH_ref` parameter docs
- `examples/inputs_random_us_weather` — commented `AH_ref` reference line

🤖 Generated with [Claude Code](https://claude.com/claude-code)
