### PR TITLE
Remove managed memory from UrbanPop initialization too

### DIFF
--- a/src/UrbanPopData.H
+++ b/src/UrbanPopData.H
@@ -56,6 +56,8 @@ struct UrbanPopData {
     void initAgents(AgentContainer& pc, const ExaEpi::TestParams& params);
 
   private:
+    void fillGridMetadataOnHost();
+
     std::map<int64_t, int> geoid_to_block_groups;
     std::map<amrex::IntVect, int> xy_to_block_groups;
     std::ifstream urbanpop_file;

--- a/src/UrbanPopData.cpp
+++ b/src/UrbanPopData.cpp
@@ -10,6 +10,7 @@
 #include <unordered_set>
 
 #include <AMReX.H>
+#include <AMReX_Arena.H>
 #include <AMReX_BLProfiler.H>
 #include <AMReX_BLassert.H>
 #include <AMReX_MultiFab.H>
@@ -255,6 +256,58 @@ void UrbanPopData::init (ExaEpi::TestParams& params, Geometry& geom, BoxArray& b
         }
         num_communities++;
     }
+
+    fillGridMetadataOnHost();
+}
+
+void UrbanPopData::fillGridMetadataOnHost () {
+    BL_PROFILE("UrbanPopData::fillGridMetadataOnHost");
+
+    iMultiFab geoid_mf_h(geoid_mf.boxArray(), geoid_mf.DistributionMap(), 2, 0, MFInfo().SetArena(The_Pinned_Arena()));
+    iMultiFab community_mf_h(community_mf.boxArray(), community_mf.DistributionMap(), 1, 0,
+                             MFInfo().SetArena(The_Pinned_Arena()));
+
+    for (MFIter mfi(geoid_mf_h); mfi.isValid(); ++mfi) {
+        auto geoid_arr = geoid_mf_h[mfi].array();
+        auto community_arr = community_mf_h[mfi].array();
+
+        const Box& box = mfi.validbox();
+        const auto lo = lbound(box);
+        const auto hi = ubound(box);
+
+        for (int x = lo.x; x <= hi.x; ++x) {
+            for (int y = lo.y; y <= hi.y; ++y) {
+                geoid_arr(x, y, 0, 0) = -1;
+                geoid_arr(x, y, 0, 1) = -1;
+                community_arr(x, y, 0) = -1;
+
+                auto it = xy_to_block_groups.find(IntVect(x, y));
+                if (it == xy_to_block_groups.end()) { continue; }
+
+                int bi = it->second;
+                AMREX_ALWAYS_ASSERT(bi >= 0 && bi < block_groups.size());
+                const auto& block_group = block_groups[bi];
+                const int64_t fips = static_cast<int64_t>(block_group.geoid / 1e7);
+
+                geoid_arr(x, y, 0, 0) = static_cast<int>(fips);
+                geoid_arr(x, y, 0, 1) = static_cast<int>(block_group.geoid - fips * 1e7);
+                community_arr(x, y, 0) = bi;
+            }
+        }
+
+        auto& geoid_src = geoid_mf_h[mfi];
+        auto& geoid_dst = geoid_mf[mfi];
+        AMREX_ALWAYS_ASSERT(geoid_src.size() == geoid_dst.size());
+        Gpu::copy(Gpu::hostToDevice, geoid_src.dataPtr(), geoid_src.dataPtr() + geoid_src.size(), geoid_dst.dataPtr());
+
+        auto& community_src = community_mf_h[mfi];
+        auto& community_dst = community_mf[mfi];
+        AMREX_ALWAYS_ASSERT(community_src.size() == community_dst.size());
+        Gpu::copy(Gpu::hostToDevice, community_src.dataPtr(), community_src.dataPtr() + community_src.size(),
+                  community_dst.dataPtr());
+    }
+
+    Gpu::streamSynchronize();
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -284,9 +337,6 @@ void UrbanPopData::initAgents (AgentContainer& pc, const ExaEpi::TestParams& par
         Vector<UrbanPopAgent> agents;
         Vector<AgentExtras> agents_extras;
 
-        auto geoid_arr = geoid_mf[mfi].array();
-        auto community_indices_arr = community_mf[mfi].array();
-
         const Box& tilebox = mfi.tilebox();
         {
             int min_x = lbound(tilebox).x;
@@ -312,12 +362,6 @@ void UrbanPopData::initAgents (AgentContainer& pc, const ExaEpi::TestParams& par
                     num_students += block_group.num_students;
                     num_educators += block_group.num_educators;
                     num_communities++;
-                    //  FIPS is the first 5 digits of the GEOID, which is 12 digits
-                    int64_t fips = static_cast<int64_t>(block_group.geoid / 1e7);
-                    geoid_arr(x, y, 0, 0) = fips;
-                    // Census tract is the 7 remaining digits after the FIPS code
-                    geoid_arr(x, y, 0, 1) = static_cast<int64_t>(block_group.geoid - fips * 1e7);
-                    community_indices_arr(x, y, 0) = bi;
                     num_nborhoods += get_max_nborhood(nborhood_size, block_group.home_population);
                 }
             }


### PR DESCRIPTION
The performance is too bad on Aurora to use this in ExaEpi. 

Also, since I changed the default of `amrex.the_arena_is_managed` to 0, the code actually segfaults on initialization without this fix. 