### PR TITLE
Fix workers/educators being pinned at home instead of their real workplace

### DIFF
--- a/src/UrbanPopData.cpp
+++ b/src/UrbanPopData.cpp
@@ -485,7 +485,18 @@ void UrbanPopData::initAgents (AgentContainer& pc, const ExaEpi::TestParams& par
             naics_ptr[i] = agent.naics;
             // set up workers
             if (agent.naics != -1) {
-                if (agent.school_id == 0) {
+                if (agent.travel == TRAVEL::_wfh) {
+                    // declared work-from-home: no real commute, and no physical collocation with
+                    // real workplace colleagues, so treat like a non-worker for workgroup/
+                    // work_nborhood purposes (naics_population/work_population describe the
+                    // assigned-but-never-visited work_geoid's community, not home, so they're not
+                    // a meaningful size for a group this agent never physically joins). Still
+                    // nominally employed (naics_ptr set above) for other purposes.
+                    workgroup_ptr[i] = 0;
+                    work_nborhood_ptr[i] = nborhood_ptr[i];
+                    work_i_ptr[i] = home_i_ptr[i];
+                    work_j_ptr[i] = home_j_ptr[i];
+                } else if (agent.school_id == 0) {
                     // the group work population for this agent is for the NAICS category for the agent
                     int max_workgroup = agents_extras_ptr[i].naics_population / workgroup_size + 1;
                     // a workgroup of 0 indicates not working
@@ -499,8 +510,6 @@ void UrbanPopData::initAgents (AgentContainer& pc, const ExaEpi::TestParams& par
                     workgroup_ptr[i] = school_id_ptr[i];
                     work_nborhood_ptr[i] = school_id_ptr[i];
                 }
-                work_i_ptr[i] = home_i_ptr[i];
-                work_j_ptr[i] = home_j_ptr[i];
             } else {
                 workgroup_ptr[i] = 0;
                 // everyone interacts in the work nborhood, even thoes that don't work (they interact during the day in their


### PR DESCRIPTION
commit 1f0d722 ("Update UrbanPop to use LODES to generate worker and student flows", 2025-08-26) unconditionally overwrote work_i/work_j back to home_i/home_j for every employed agent (naics != -1) right after correctly computing their real workplace position from agents_extras[i]. work_xy. This meant workers and educators never actually relocated to their workplace community during the day -- moveAgentsToWork() only ever moved them to where they already were, so all daytime community-level transmission (xmit_comm) happened in agents' home communities regardless of employment, and InteractionModWork.H's workgroup bucketing (keyed by current physical community) grouped agents by home rather than by real workplace.

Before that commit, work_i/work_j were set directly from the agent's real work longitude/latitude for everyone, with no home-pinning override; only a narrower ROLE::worker && naics != NAICS::wfh check gated the workgroup- population lookup, not the position itself. That distinction (real commuters vs. declared work-from-home) got collapsed into a single naics != -1 check during the refactor, so the home-pinning meant only for work-from-home agents ended up applying to everyone employed.

Restore the distinction using the current data model's equivalent field, agent.travel == TRAVEL::_wfh (declared work-from-home commute mode, from the same UrbanPopAgent record, independent of naics/industry sector): real commuters now keep their genuine workplace position, while WFH agents stay pinned at home and are also excluded from workgroup/ work_nborhood transmission entirely (workgroup=0, matching the existing "not working" convention), since their naics_population/work_population describe a workplace community they never physically occupy.

Confirmed via upop_to_exaepi.py that work_geoid assignment (LODES flow sampling in alloc_workers()) is independent of the pr_travel attribute, so this inconsistency isn't already resolved upstream in data generation -- the fix has to live here.